### PR TITLE
Validate workflow file format, fix workflow cost aggregation, and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ An open-source profiler for AI agents that analyzes token usage, cost, latency, 
 uv sync --extra dev
 ```
 
+Run the sync command once before development checks so tools such as `pytest-cov`,
+`ruff`, and `mypy` are available in the project environment.
+
 ## Usage
 
 ```python
@@ -24,6 +27,7 @@ with profile("Customer Support"):
 ## Development
 
 ```bash
+uv sync --extra dev      # install/update the dev environment
 uv run pytest          # tests
 uv run ruff check .    # lint
 uv run ruff format .   # format

--- a/src/agenticlens/__init__.py
+++ b/src/agenticlens/__init__.py
@@ -1,5 +1,5 @@
 from agenticlens.profiler import StepHandle, profile, step
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ["StepHandle", "__version__", "profile", "step"]

--- a/src/agenticlens/cli/main.py
+++ b/src/agenticlens/cli/main.py
@@ -22,6 +22,13 @@ def _load_workflow(path: Path) -> Workflow:
     if not path.exists():
         console.print(f"[red]File not found:[/red] {path}")
         raise typer.Exit(code=1)
+    if path.suffix.lower() != ".json":
+        console.print(
+            f"[red]Unsupported workflow file format:[/red] {path.suffix or '<none>'}. "
+            "Use a JSON workflow export for report/analyze commands; CSV exports are "
+            "step breakdowns only."
+        )
+        raise typer.Exit(code=1)
     return Workflow.model_validate_json(path.read_text())
 
 

--- a/src/agenticlens/config/settings.py
+++ b/src/agenticlens/config/settings.py
@@ -25,11 +25,7 @@ class AgenticLensConfig(BaseModel):
 
 
 def load_config(path: str | Path | None = None) -> AgenticLensConfig:
-    """Load configuration from an explicit path, $AGENTICLENS_CONFIG, or defaults.
-
-    Supports a YAML file. `pyproject.toml`-based config ([tool.agenticlens]) is
-    planned but not yet implemented in this scaffold.
-    """
+    """Load configuration from an explicit YAML path, $AGENTICLENS_CONFIG, or defaults."""
     config_path = path or os.environ.get(CONFIG_ENV_VAR)
     if config_path is None:
         return AgenticLensConfig()

--- a/src/agenticlens/models/workflow.py
+++ b/src/agenticlens/models/workflow.py
@@ -21,9 +21,13 @@ class Workflow(BaseModel):
 
     @property
     def total_cost(self) -> float | None:
-        costs = [step.metrics.cost for step in self.steps if step.metrics.cost is not None]
-        if not costs:
+        if not self.steps:
             return None
+        costs = []
+        for step in self.steps:
+            if step.metrics.cost is None:
+                return None
+            costs.append(step.metrics.cost)
         return sum(costs)
 
     @property

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,6 +104,17 @@ def test_cli_report_missing_file() -> None:
     assert "not found" in result.output.lower()
 
 
+def test_cli_report_rejects_csv_exports(tmp_path: Path) -> None:
+    out = tmp_path / "report.csv"
+    out.write_text("step_name,total_tokens\nPlanner,15\n")
+
+    result = runner.invoke(app, ["report", str(out)])
+
+    assert result.exit_code == 1
+    assert "unsupported workflow file format" in result.output.lower()
+    assert "csv exports are step breakdowns only" in result.output.lower()
+
+
 def test_cli_analyze_flags_duplicate_tool_calls(tmp_path: Path) -> None:
     from datetime import datetime, timezone
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,6 +32,26 @@ def test_workflow_total_cost_none_when_unpriced() -> None:
     assert workflow.total_cost is None
 
 
+def test_workflow_total_cost_none_when_partially_unpriced() -> None:
+    workflow = Workflow(name="Test Workflow", start_time=datetime.now(timezone.utc))
+    workflow.steps.append(
+        Step(
+            name="Planner",
+            type=StepType.PLANNER,
+            metrics=Metrics(prompt_tokens=100, completion_tokens=50, total_tokens=150, cost=0.01),
+        )
+    )
+    workflow.steps.append(
+        Step(
+            name="Unknown model call",
+            type=StepType.LLM_CALL,
+            metrics=Metrics(prompt_tokens=20, completion_tokens=10, total_tokens=30),
+        )
+    )
+
+    assert workflow.total_cost is None
+
+
 def test_metrics_tps() -> None:
     metrics = Metrics(completion_tokens=100, latency=2.0)
     assert metrics.tps == 50.0


### PR DESCRIPTION
### Motivation

- Ensure CLI `report`/`analyze` commands only consume full workflow exports (JSON) and provide clear errors for CSV step-breakdowns.
- Make workflow-level cost aggregation accurate by returning `None` when any step is unpriced instead of summing partial costs.
- Bump the package version and improve README/development instructions for setting up dev tools.

### Description

- Added a file format check in `_load_workflow` to reject non-JSON files with a clear `typer.Exit` message and guidance that CSV exports are step breakdowns only. 
- Changed `Workflow.total_cost` to return `None` if there are no steps or if any step has `metrics.cost is None`, otherwise sum all step costs.
- Bumped package `__version__` from `0.1.0` to `0.1.1`.
- Small README updates to recommend running `uv sync --extra dev` before development checks and duplicated the sync step in the development commands for clarity.
- Clarified `load_config` docstring to state YAML/ENV loading behavior.
- Added automated tests: `test_cli_report_rejects_csv_exports` in `tests/test_cli.py` and `test_workflow_total_cost_none_when_partially_unpriced` in `tests/test_models.py` to cover the new behaviors.

### Testing

- Ran the test suite with `uv run pytest`, and the test run completed successfully.
- The new CLI test `tests/test_cli.py::test_cli_report_rejects_csv_exports` passed and verifies CLI exit code and error message for CSV inputs.
- The new model test `tests/test_models.py::test_workflow_total_cost_none_when_partially_unpriced` passed and verifies `Workflow.total_cost` is `None` when any step is unpriced.
- Existing CLI and model tests were exercised as part of the suite and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b452c2b248329a4d15c890df5b9c1)