### PR TITLE
Rag scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,23 @@ from agenticlens.exporters import MarkdownExporter
 MarkdownExporter().export(workflow, "report.md")
 ```
 
+### With Recommendations
+
+All exporters (except Jira) support an optional `recommendations` parameter:
+
+```python
+from agenticlens.exporters import MarkdownExporter, JSONExporter, CSVExporter
+from agenticlens.recommenders import RecommendationEngine
+
+engine = RecommendationEngine()
+recs = engine.run(workflow)
+
+MarkdownExporter().export(workflow, "report.md", recommendations=recs)
+JSONExporter().export(workflow, "report.json", recommendations=recs)
+CSVExporter().export(workflow, "steps.csv", recommendations=recs)
+# CSV also writes steps_recommendations.csv alongside
+```
+
 ### Jira Integration
 
 Post profiling results directly as a comment on a Jira issue:

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ MarkdownExporter().export(workflow, "report.md")
 
 ### With Recommendations
 
-All exporters (except Jira) support an optional `recommendations` parameter:
+All exporters accept an optional `recommendations` parameter (Jira currently ignores it):
 
 ```python
 from agenticlens.exporters import MarkdownExporter, JSONExporter, CSVExporter

--- a/README.md
+++ b/README.md
@@ -184,19 +184,31 @@ This keeps reporting honest when model pricing is missing or stale.
 
 ## RAG Chunk Utility
 
-The RAG utility rule compares retrieved context with useful context. It can use
-explicit chunk metadata such as:
+The RAG utility rule identifies retrieved chunks that are unlikely to influence
+the final answer. It supports multiple signal types (in priority order):
+
+| Signal Type | Supported Fields | Source |
+| --- | --- | --- |
+| Citation | `cited`, `used`, `referenced` (boolean) | Your app logic |
+| Reranker | `reranker_score`, `rerank_score`, `cross_encoder_score` (0–1) | Cross-encoder models |
+| Embedding | `embedding_similarity`, `cosine_similarity`, `semantic_score` (0–1) | Vector search |
+| Generic | `utility_score`, `relevance_score` (0–1) | Custom scoring |
+| Fallback | Word-overlap against final answer | Automatic |
+
+Example chunk metadata:
 
 ```python
-{"text": "...", "utility_score": 0.92}
-{"text": "...", "used": True}
-{"text": "...", "cited": False}
+{"text": "...", "reranker_score": 0.92}
+{"text": "...", "cosine_similarity": 0.85}
+{"text": "...", "cited": True}
+{"text": "...", "utility_score": 0.12}
 ```
 
-If explicit signals are unavailable, it falls back to lightweight word-overlap
-between retrieved chunks and the final answer. That fallback is intentionally
-conservative: it identifies potentially low-utility context, not chunks that are
-guaranteed safe to remove.
+When rich signals (reranker, embedding, citation) are available, confidence is
+higher and quality risk is lower. If no explicit signals are present, it falls
+back to lightweight word-overlap against the final answer.
+
+For a complete guide, see [docs/rag-chunk-utility.md](docs/rag-chunk-utility.md).
 
 ## Examples
 
@@ -213,6 +225,7 @@ Other examples:
 - `examples/rag_customer_support_demo.py`
 - `examples/multiagent_support_demo.py`
 - `examples/export_demo.py` — export to Markdown and Jira
+- `examples/rag_scoring_demo.py` — RAG chunk utility with reranker/embedding/citation signals
 
 Some examples call real provider APIs and require provider API keys.
 

--- a/docs/rag-chunk-utility.md
+++ b/docs/rag-chunk-utility.md
@@ -118,7 +118,9 @@ with profile("RAG Pipeline") as workflow:
         model="gpt-4o-mini",
         final_answer="You can return within 30 days if unused.",
     ) as s:
-        s.record(response)
+        # Record your provider response to capture token usage.
+        # Must expose .usage.prompt_tokens and .usage.completion_tokens.
+        s.record(your_llm_response)
 ```
 
 ### Expected Output

--- a/docs/rag-chunk-utility.md
+++ b/docs/rag-chunk-utility.md
@@ -1,0 +1,162 @@
+# RAG Chunk Utility Scoring
+
+AgenticLens can identify low-utility retrieved chunks that waste tokens without
+contributing to the final answer. This guide explains the supported signal types
+and how to use them.
+
+---
+
+## How It Works
+
+When a retriever step includes `retrieved_chunks` in its metadata, the
+`RAGChunkUtilityRecommender` scores each chunk to determine whether it was
+useful. Chunks scoring below the threshold (`rag_min_chunk_utility_score`,
+default 0.08) are flagged as low-utility.
+
+---
+
+## Supported Signals (Priority Order)
+
+### 1. Citation Signals
+
+Boolean fields that indicate whether the chunk was actually used in the response.
+
+```python
+{"text": "Refunds take 5-10 days.", "cited": True}
+{"text": "Warehouse inventory system.", "cited": False}
+{"text": "Used in answer.", "referenced": True}
+{"text": "Old policy doc.", "used": False}
+```
+
+**Fields:** `cited`, `used`, `referenced`
+**Values:** `True` → score 1.0, `False` → score 0.0
+
+### 2. Reranker Scores
+
+Cross-encoder or reranker confidence scores (0 to 1).
+
+```python
+{"text": "Highly relevant passage.", "reranker_score": 0.95}
+{"text": "Marginally relevant.", "reranker_score": 0.45}
+{"text": "Irrelevant noise.", "cross_encoder_score": 0.02}
+```
+
+**Fields:** `reranker_score`, `rerank_score`, `cross_encoder_score`
+**Values:** Float 0.0–1.0
+
+### 3. Embedding Similarity
+
+Cosine similarity between chunk embedding and query/answer embedding.
+
+```python
+{"text": "Semantically close.", "cosine_similarity": 0.88}
+{"text": "Distant meaning.", "embedding_similarity": 0.12}
+{"text": "Moderate match.", "semantic_score": 0.55}
+```
+
+**Fields:** `embedding_similarity`, `cosine_similarity`, `semantic_score`
+**Values:** Float 0.0–1.0
+
+### 4. Generic Utility Scores
+
+Any custom scoring your pipeline provides.
+
+```python
+{"text": "Custom scored chunk.", "utility_score": 0.73}
+{"text": "Low relevance.", "relevance_score": 0.05}
+```
+
+**Fields:** `utility_score`, `relevance_score`, `answer_overlap`
+**Values:** Float 0.0–1.0
+
+### 5. Fallback: Word Overlap
+
+If none of the above fields are present, the rule computes word overlap between
+the chunk text and the final answer found in the workflow. This is intentionally
+conservative — it only catches obviously irrelevant chunks.
+
+---
+
+## Confidence and Quality Risk
+
+| Signal Source | Confidence Range | Quality Risk |
+|--------------|-----------------|--------------|
+| Citation / Reranker / Embedding | 0.65–0.95 | low |
+| Word-overlap fallback | 0.45–0.85 | medium |
+
+Rich signals yield higher confidence because they come from models specifically
+designed to assess relevance, whereas word overlap is a rough heuristic.
+
+---
+
+## Usage Example
+
+```python
+from agenticlens import profile, step
+
+with profile("RAG Pipeline") as workflow:
+    with step(
+        "Retriever",
+        type="retriever",
+        chunk_count=6,
+        avg_tokens_per_chunk=80,
+        retrieved_chunks=[
+            {"text": "Refund policy: within 30 days.", "reranker_score": 0.92},
+            {"text": "Returns must be unused.", "reranker_score": 0.78},
+            {"text": "Office hours: 9-5 weekdays.", "reranker_score": 0.03},
+            {"text": "Parking info for visitors.", "reranker_score": 0.01},
+            {"text": "Shipping takes 5-7 days.", "cosine_similarity": 0.41},
+            {"text": "CEO biography page.", "cosine_similarity": 0.05},
+        ],
+    ):
+        pass
+
+    with step(
+        "Final Answer",
+        type="final_response",
+        provider="openai",
+        model="gpt-4o-mini",
+        final_answer="You can return within 30 days if unused.",
+    ) as s:
+        s.record(response)
+```
+
+### Expected Output
+
+```text
+Budget Optimization Run cost: $0.0045; reducible: ~$0.0019/run (42%)
+
+Optimization Suggestions
+  * Low-utility retrieved chunks
+    Step 'Retriever' retrieved 3 chunks that appear unlikely to
+    influence the final answer (6 chunks scored). Consider lowering
+    top-k, tightening retrieval filters, or reranking before generation.
+
+    Tokens saved: 240
+    Confidence: 0.90
+    Quality risk: low
+```
+
+---
+
+## Configuration
+
+In your AgenticLens config (YAML):
+
+```yaml
+recommender:
+  rag_min_chunk_utility_score: 0.08   # Threshold below which a chunk is "low-utility"
+  rag_min_low_utility_chunks: 2       # Minimum low-utility chunks before flagging
+```
+
+---
+
+## When to Use Which Signal
+
+| Your Setup | Best Signal |
+|-----------|-------------|
+| You have a reranker in your pipeline | `reranker_score` |
+| You store cosine similarity from vector search | `cosine_similarity` |
+| You track which chunks the LLM actually cited | `cited` |
+| You have a custom relevance model | `utility_score` |
+| No scoring available | Automatic word-overlap fallback |

--- a/examples/export_demo.py
+++ b/examples/export_demo.py
@@ -2,12 +2,14 @@
 
 This demonstrates how to use the MarkdownExporter and JiraExporter
 to share profiling results as human-readable reports or Jira comments.
+Also shows how to include optimization recommendations in exports.
 """
 
 import os
 
 from agenticlens import profile, step
 from agenticlens.exporters import JiraExporter, MarkdownExporter
+from agenticlens.recommenders import RecommendationEngine
 
 
 class FakeUsage:
@@ -48,9 +50,12 @@ def run_workflow():
 
 
 def export_markdown(workflow) -> None:
-    """Export workflow report to a Markdown file."""
-    MarkdownExporter().export(workflow, "workflow_report.md")
-    print("Markdown report saved to workflow_report.md")
+    """Export workflow report to a Markdown file, including recommendations."""
+    engine = RecommendationEngine()
+    recs = engine.run(workflow)
+
+    MarkdownExporter().export(workflow, "workflow_report.md", recommendations=recs)
+    print(f"Markdown report saved to workflow_report.md ({len(recs)} recommendations)")
 
 
 def export_to_jira(workflow) -> None:

--- a/examples/rag_scoring_demo.py
+++ b/examples/rag_scoring_demo.py
@@ -1,0 +1,135 @@
+"""Example: RAG chunk utility scoring with reranker, embedding, and citation signals.
+
+Demonstrates how AgenticLens detects low-utility retrieved chunks using
+different signal types. Run with:
+
+    uv run agenticlens profile examples/rag_scoring_demo.py --save rag_scoring.json
+    uv run agenticlens analyze rag_scoring.json
+"""
+
+import time
+
+from agenticlens import profile, step
+
+
+class FakeUsage:
+    def __init__(self, prompt_tokens: int, completion_tokens: int) -> None:
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
+class FakeResponse:
+    def __init__(self, prompt_tokens: int, completion_tokens: int) -> None:
+        self.usage = FakeUsage(prompt_tokens, completion_tokens)
+
+
+def main() -> None:
+    with profile("RAG Scoring Demo") as workflow:
+        # Step 1: Retriever with reranker scores
+        with step(
+            "Retriever (reranker scored)",
+            type="retriever",
+            chunk_count=6,
+            avg_tokens_per_chunk=80,
+            retrieved_chunks=[
+                {
+                    "text": "Refund policy: Customers can request a refund within 30 days.",
+                    "reranker_score": 0.94,
+                },
+                {
+                    "text": "Returns must be in original packaging and unused.",
+                    "reranker_score": 0.82,
+                },
+                {
+                    "text": "Refunds are processed to the original payment method.",
+                    "reranker_score": 0.76,
+                },
+                {
+                    "text": "Office parking is available on level B2.",
+                    "reranker_score": 0.03,
+                },
+                {
+                    "text": "Company holiday schedule for 2025.",
+                    "reranker_score": 0.01,
+                },
+                {
+                    "text": "Internal meeting room booking system.",
+                    "reranker_score": 0.02,
+                },
+            ],
+        ):
+            time.sleep(0.1)
+
+        # Step 2: Retriever with embedding similarity scores
+        with step(
+            "Retriever (embedding scored)",
+            type="retriever",
+            chunk_count=4,
+            avg_tokens_per_chunk=60,
+            retrieved_chunks=[
+                {
+                    "text": "Shipping takes 5-7 business days for standard delivery.",
+                    "cosine_similarity": 0.85,
+                },
+                {
+                    "text": "Express shipping available for 2-3 day delivery.",
+                    "cosine_similarity": 0.72,
+                },
+                {
+                    "text": "CEO announced new sustainability initiative.",
+                    "cosine_similarity": 0.08,
+                },
+                {
+                    "text": "Cafeteria menu updated for summer.",
+                    "embedding_similarity": 0.04,
+                },
+            ],
+        ):
+            time.sleep(0.1)
+
+        # Step 3: Retriever with citation signals (post-hoc)
+        with step(
+            "Retriever (citation tracked)",
+            type="retriever",
+            chunk_count=5,
+            avg_tokens_per_chunk=70,
+            retrieved_chunks=[
+                {"text": "Refunds may take 5 to 10 business days.", "cited": True},
+                {"text": "Contact support for order issues.", "cited": True},
+                {"text": "Warehouse inventory management.", "cited": False},
+                {"text": "Employee onboarding checklist.", "cited": False},
+                {"text": "IT security policy document.", "referenced": False},
+            ],
+        ):
+            time.sleep(0.1)
+
+        # Step 4: Final answer generation
+        with step(
+            "Final Answer",
+            type="final_response",
+            provider="openai",
+            model="gpt-4o-mini",
+            final_answer=(
+                "You can request a refund within 30 days if the item is unused "
+                "and in original packaging. Refunds are processed to the original "
+                "payment method and may take 5 to 10 business days."
+            ),
+        ) as s:
+            s.record(FakeResponse(prompt_tokens=450, completion_tokens=65))
+
+    # Print results
+    print(f"Workflow: {workflow.name}")
+    print(f"Total tokens: {workflow.total_tokens}")
+    print(f"Steps: {len(workflow.steps)}")
+    print()
+
+    for s in workflow.steps:
+        chunks = s.metadata.get("retrieved_chunks", [])
+        if chunks:
+            print(f"  {s.name}: {len(chunks)} chunks retrieved")
+        else:
+            print(f"  {s.name}: {s.metrics.total_tokens} tokens")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,5 +6,6 @@ theme:
 nav:
   - Home: index.md
   - Export Formats: export-formats.md
+  - RAG Chunk Utility: rag-chunk-utility.md
 
 repo_url: https://github.com/agenticlens/agenticlens

--- a/src/agenticlens/exporters/base.py
+++ b/src/agenticlens/exporters/base.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agenticlens.models.recommendation import Recommendation
 
 from agenticlens.models.workflow import Workflow
 
@@ -8,5 +14,10 @@ class BaseExporter(ABC):
     """Interface for exporting a profiled Workflow to a file format."""
 
     @abstractmethod
-    def export(self, workflow: Workflow, path: str | Path) -> None:
+    def export(
+        self,
+        workflow: Workflow,
+        path: str | Path | None = None,
+        recommendations: list[Recommendation] | None = None,
+    ) -> None:
         raise NotImplementedError

--- a/src/agenticlens/exporters/csv_exporter.py
+++ b/src/agenticlens/exporters/csv_exporter.py
@@ -39,9 +39,11 @@ class CSVExporter(BaseExporter):
     def export(
         self,
         workflow: Workflow,
-        path: str | Path,
+        path: str | Path | None = None,
         recommendations: list[Recommendation] | None = None,
     ) -> None:
+        if path is None:
+            raise ValueError("CSVExporter requires a path")
         path = Path(path)
         with path.open("w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=STEP_FIELDNAMES)

--- a/src/agenticlens/exporters/csv_exporter.py
+++ b/src/agenticlens/exporters/csv_exporter.py
@@ -2,9 +2,10 @@ import csv
 from pathlib import Path
 
 from agenticlens.exporters.base import BaseExporter
+from agenticlens.models.recommendation import Recommendation
 from agenticlens.models.workflow import Workflow
 
-FIELDNAMES = [
+STEP_FIELDNAMES = [
     "step_id",
     "step_name",
     "step_type",
@@ -18,13 +19,32 @@ FIELDNAMES = [
     "cost",
 ]
 
+RECOMMENDATION_FIELDNAMES = [
+    "title",
+    "severity",
+    "tokens_saved",
+    "confidence",
+    "quality_risk",
+    "description",
+]
+
 
 class CSVExporter(BaseExporter):
-    """Exports a per-step breakdown of a workflow to CSV."""
+    """Exports a per-step breakdown of a workflow to CSV.
 
-    def export(self, workflow: Workflow, path: str | Path) -> None:
-        with Path(path).open("w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+    If recommendations are provided, a second file is written alongside
+    with a '_recommendations' suffix containing the optimization suggestions.
+    """
+
+    def export(
+        self,
+        workflow: Workflow,
+        path: str | Path,
+        recommendations: list[Recommendation] | None = None,
+    ) -> None:
+        path = Path(path)
+        with path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=STEP_FIELDNAMES)
             writer.writeheader()
             for s in workflow.steps:
                 writer.writerow(
@@ -42,3 +62,20 @@ class CSVExporter(BaseExporter):
                         "cost": s.metrics.cost,
                     }
                 )
+
+        if recommendations:
+            rec_path = path.with_name(f"{path.stem}_recommendations{path.suffix}")
+            with rec_path.open("w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=RECOMMENDATION_FIELDNAMES)
+                writer.writeheader()
+                for rec in recommendations:
+                    writer.writerow(
+                        {
+                            "title": rec.title,
+                            "severity": rec.severity.value,
+                            "tokens_saved": rec.tokens_saved,
+                            "confidence": rec.confidence,
+                            "quality_risk": rec.quality_risk,
+                            "description": rec.description,
+                        }
+                    )

--- a/src/agenticlens/exporters/jira_exporter.py
+++ b/src/agenticlens/exporters/jira_exporter.py
@@ -7,6 +7,7 @@ from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 from agenticlens.exporters.base import BaseExporter
+from agenticlens.models.recommendation import Recommendation
 from agenticlens.models.workflow import Workflow
 
 
@@ -42,7 +43,12 @@ class JiraExporter(BaseExporter):
         self.api_token = api_token
         self.issue_key = issue_key
 
-    def export(self, workflow: Workflow, path: str | Path | None = None) -> None:
+    def export(
+        self,
+        workflow: Workflow,
+        path: str | Path | None = None,
+        recommendations: list[Recommendation] | None = None,
+    ) -> None:
         """Post workflow metrics as a comment on the configured Jira issue.
 
         The *path* parameter is accepted for interface compatibility but is not

--- a/src/agenticlens/exporters/json_exporter.py
+++ b/src/agenticlens/exporters/json_exporter.py
@@ -1,9 +1,21 @@
+import json
 from pathlib import Path
 
 from agenticlens.exporters.base import BaseExporter
+from agenticlens.models.recommendation import Recommendation
 from agenticlens.models.workflow import Workflow
 
 
 class JSONExporter(BaseExporter):
-    def export(self, workflow: Workflow, path: str | Path) -> None:
-        Path(path).write_text(workflow.model_dump_json(indent=2))
+    def export(
+        self,
+        workflow: Workflow,
+        path: str | Path,
+        recommendations: list[Recommendation] | None = None,
+    ) -> None:
+        data = json.loads(workflow.model_dump_json())
+        if recommendations:
+            data["recommendations"] = [
+                rec.model_dump(exclude_none=True) for rec in recommendations
+            ]
+        Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/src/agenticlens/exporters/json_exporter.py
+++ b/src/agenticlens/exporters/json_exporter.py
@@ -10,10 +10,14 @@ class JSONExporter(BaseExporter):
     def export(
         self,
         workflow: Workflow,
-        path: str | Path,
+        path: str | Path | None = None,
         recommendations: list[Recommendation] | None = None,
     ) -> None:
-        data = json.loads(workflow.model_dump_json())
+        data = workflow.model_dump(mode="json")
         if recommendations:
-            data["recommendations"] = [rec.model_dump(exclude_none=True) for rec in recommendations]
+            data["recommendations"] = [
+                rec.model_dump(mode="json", exclude_none=True) for rec in recommendations
+            ]
+        if path is None:
+            raise ValueError("JSONExporter requires a path")
         Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/src/agenticlens/exporters/json_exporter.py
+++ b/src/agenticlens/exporters/json_exporter.py
@@ -15,7 +15,5 @@ class JSONExporter(BaseExporter):
     ) -> None:
         data = json.loads(workflow.model_dump_json())
         if recommendations:
-            data["recommendations"] = [
-                rec.model_dump(exclude_none=True) for rec in recommendations
-            ]
+            data["recommendations"] = [rec.model_dump(exclude_none=True) for rec in recommendations]
         Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/src/agenticlens/exporters/markdown_exporter.py
+++ b/src/agenticlens/exporters/markdown_exporter.py
@@ -11,7 +11,7 @@ class MarkdownExporter(BaseExporter):
     def export(
         self,
         workflow: Workflow,
-        path: str | Path,
+        path: str | Path | None = None,
         recommendations: list[Recommendation] | None = None,
     ) -> None:
         lines: list[str] = []
@@ -63,6 +63,8 @@ class MarkdownExporter(BaseExporter):
                     lines.append(f"- **Quality Risk:** {rec.quality_risk}")
                 lines.append(f"\n{rec.description}\n")
 
+        if path is None:
+            raise ValueError("MarkdownExporter requires a path")
         Path(path).write_text("\n".join(lines), encoding="utf-8")
 
     @staticmethod

--- a/src/agenticlens/exporters/markdown_exporter.py
+++ b/src/agenticlens/exporters/markdown_exporter.py
@@ -1,13 +1,19 @@
 from pathlib import Path
 
 from agenticlens.exporters.base import BaseExporter
+from agenticlens.models.recommendation import Recommendation
 from agenticlens.models.workflow import Workflow
 
 
 class MarkdownExporter(BaseExporter):
     """Exports a workflow profiling report as a human-readable Markdown file."""
 
-    def export(self, workflow: Workflow, path: str | Path) -> None:
+    def export(
+        self,
+        workflow: Workflow,
+        path: str | Path,
+        recommendations: list[Recommendation] | None = None,
+    ) -> None:
         lines: list[str] = []
         safe_name = workflow.name.replace("|", "\\|").replace("\r", "").replace("\n", " ")
         lines.append(f"# Workflow Report: {safe_name}\n")
@@ -43,6 +49,19 @@ class MarkdownExporter(BaseExporter):
                 f"| {s.metrics.latency:.2f}s | {self._fmt_cost(s.metrics.cost)} |"
             )
         lines.append("")
+
+        # Recommendations section
+        if recommendations:
+            lines.append("## Optimization Recommendations\n")
+            for rec in recommendations:
+                lines.append(f"### {rec.title}\n")
+                lines.append(f"- **Severity:** {rec.severity.value}")
+                lines.append(f"- **Tokens Saved:** {rec.tokens_saved:,}")
+                if rec.confidence is not None:
+                    lines.append(f"- **Confidence:** {rec.confidence:.0%}")
+                if rec.quality_risk:
+                    lines.append(f"- **Quality Risk:** {rec.quality_risk}")
+                lines.append(f"\n{rec.description}\n")
 
         Path(path).write_text("\n".join(lines), encoding="utf-8")
 

--- a/src/agenticlens/recommenders/rag_chunk_utility.py
+++ b/src/agenticlens/recommenders/rag_chunk_utility.py
@@ -58,9 +58,10 @@ class RAGChunkUtilityRecommender(BaseRecommender):
             scored_count = 0
             has_rich_signals = False
             for chunk in chunks:
-                utility_score = self._explicit_utility_score(chunk)
+                utility_score, is_rich = self._explicit_utility_score(chunk)
                 if utility_score is not None:
-                    has_rich_signals = True
+                    if is_rich:
+                        has_rich_signals = True
                 elif final_answer:
                     utility_score = self._answer_overlap_score(
                         self._chunk_text(chunk),
@@ -124,35 +125,40 @@ class RAGChunkUtilityRecommender(BaseRecommender):
         return min(0.95, 0.45 + coverage * 0.4)
 
     @staticmethod
-    def _explicit_utility_score(chunk: Any) -> float | None:
+    def _explicit_utility_score(chunk: Any) -> tuple[float | None, bool]:
+        """Return (score, is_rich_signal) for a chunk.
+
+        Rich signals (citation, reranker, embedding) yield higher confidence.
+        Generic scores (utility_score, relevance_score) are not considered rich.
+        """
         if not isinstance(chunk, dict):
-            return None
+            return None, False
 
         # Citation signal: was this chunk cited in the final answer?
         for key in ("cited", "used", "referenced"):
             value = chunk.get(key)
             if isinstance(value, bool):
-                return 1.0 if value else 0.0
+                return (1.0 if value else 0.0), True
 
         # Reranker score: cross-encoder or reranker confidence (0-1)
         for key in ("reranker_score", "rerank_score", "cross_encoder_score"):
             value = chunk.get(key)
-            if isinstance(value, int | float):
-                return max(0.0, min(1.0, float(value)))
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return max(0.0, min(1.0, float(value))), True
 
         # Embedding similarity: cosine similarity between chunk and query/answer
         for key in ("embedding_similarity", "cosine_similarity", "semantic_score"):
             value = chunk.get(key)
-            if isinstance(value, int | float):
-                return max(0.0, min(1.0, float(value)))
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return max(0.0, min(1.0, float(value))), True
 
-        # Generic utility/relevance scores
+        # Generic utility/relevance scores (not considered "rich")
         for key in ("utility_score", "relevance_score", "answer_overlap"):
             value = chunk.get(key)
-            if isinstance(value, int | float):
-                return max(0.0, min(1.0, float(value)))
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return max(0.0, min(1.0, float(value))), False
 
-        return None
+        return None, False
 
     @staticmethod
     def _chunk_text(chunk: Any) -> str:

--- a/src/agenticlens/recommenders/rag_chunk_utility.py
+++ b/src/agenticlens/recommenders/rag_chunk_utility.py
@@ -57,12 +57,19 @@ class RAGChunkUtilityRecommender(BaseRecommender):
             low_utility_count = 0
             scored_count = 0
             has_rich_signals = False
+
+            # First pass: check if any chunk has rich signals
             for chunk in chunks:
-                utility_score, is_rich = self._explicit_utility_score(chunk)
-                if utility_score is not None:
-                    if is_rich:
-                        has_rich_signals = True
-                elif final_answer:
+                _, is_rich = self._explicit_utility_score(chunk)
+                if is_rich:
+                    has_rich_signals = True
+                    break
+
+            # Second pass: score all chunks
+            for chunk in chunks:
+                utility_score, _ = self._explicit_utility_score(chunk)
+                if utility_score is None and not has_rich_signals and final_answer:
+                    # Only use word-overlap fallback if NO chunk has rich signals
                     utility_score = self._answer_overlap_score(
                         self._chunk_text(chunk),
                         final_answer,

--- a/src/agenticlens/recommenders/rag_chunk_utility.py
+++ b/src/agenticlens/recommenders/rag_chunk_utility.py
@@ -57,19 +57,22 @@ class RAGChunkUtilityRecommender(BaseRecommender):
             low_utility_count = 0
             scored_count = 0
             has_rich_signals = False
+            has_any_explicit = False
 
-            # First pass: check if any chunk has rich signals
+            # First pass: check if any chunk has explicit signals
             for chunk in chunks:
-                _, is_rich = self._explicit_utility_score(chunk)
-                if is_rich:
-                    has_rich_signals = True
-                    break
+                score, is_rich = self._explicit_utility_score(chunk)
+                if score is not None:
+                    has_any_explicit = True
+                    if is_rich:
+                        has_rich_signals = True
+                        break
 
             # Second pass: score all chunks
             for chunk in chunks:
                 utility_score, _ = self._explicit_utility_score(chunk)
-                if utility_score is None and not has_rich_signals and final_answer:
-                    # Only use word-overlap fallback if NO chunk has rich signals
+                if utility_score is None and not has_any_explicit and final_answer:
+                    # Only use word-overlap fallback if NO chunk has explicit scores
                     utility_score = self._answer_overlap_score(
                         self._chunk_text(chunk),
                         final_answer,
@@ -128,7 +131,7 @@ class RAGChunkUtilityRecommender(BaseRecommender):
         if has_rich_signals:
             # Reranker/embedding/citation signals are more reliable
             return min(0.95, 0.65 + coverage * 0.3)
-        # Word-overlap fallback is less reliable
+        # Generic signals / word-overlap fallback are less reliable
         return min(0.95, 0.45 + coverage * 0.4)
 
     @staticmethod

--- a/src/agenticlens/recommenders/rag_chunk_utility.py
+++ b/src/agenticlens/recommenders/rag_chunk_utility.py
@@ -56,9 +56,12 @@ class RAGChunkUtilityRecommender(BaseRecommender):
 
             low_utility_count = 0
             scored_count = 0
+            has_rich_signals = False
             for chunk in chunks:
                 utility_score = self._explicit_utility_score(chunk)
-                if utility_score is None and final_answer:
+                if utility_score is not None:
+                    has_rich_signals = True
+                elif final_answer:
                     utility_score = self._answer_overlap_score(
                         self._chunk_text(chunk),
                         final_answer,
@@ -90,8 +93,10 @@ class RAGChunkUtilityRecommender(BaseRecommender):
                     ),
                     severity=Severity.WARNING,
                     tokens_saved=tokens_saved,
-                    confidence=min(0.95, 0.45 + (scored_count / max(len(chunks), 1)) * 0.4),
-                    quality_risk="medium",
+                    confidence=self._compute_confidence(
+                        scored_count, len(chunks), has_rich_signals,
+                    ),
+                    quality_risk="low" if has_rich_signals else "medium",
                 )
             )
 
@@ -107,15 +112,41 @@ class RAGChunkUtilityRecommender(BaseRecommender):
         return None
 
     @staticmethod
+    def _compute_confidence(
+        scored_count: int, total_chunks: int, has_rich_signals: bool
+    ) -> float:
+        """Higher confidence when rich signals (reranker/embedding/citation) are present."""
+        coverage = scored_count / max(total_chunks, 1)
+        if has_rich_signals:
+            # Reranker/embedding/citation signals are more reliable
+            return min(0.95, 0.65 + coverage * 0.3)
+        # Word-overlap fallback is less reliable
+        return min(0.95, 0.45 + coverage * 0.4)
+
+    @staticmethod
     def _explicit_utility_score(chunk: Any) -> float | None:
         if not isinstance(chunk, dict):
             return None
 
-        for key in ("used", "cited"):
+        # Citation signal: was this chunk cited in the final answer?
+        for key in ("cited", "used", "referenced"):
             value = chunk.get(key)
             if isinstance(value, bool):
                 return 1.0 if value else 0.0
 
+        # Reranker score: cross-encoder or reranker confidence (0-1)
+        for key in ("reranker_score", "rerank_score", "cross_encoder_score"):
+            value = chunk.get(key)
+            if isinstance(value, int | float):
+                return max(0.0, min(1.0, float(value)))
+
+        # Embedding similarity: cosine similarity between chunk and query/answer
+        for key in ("embedding_similarity", "cosine_similarity", "semantic_score"):
+            value = chunk.get(key)
+            if isinstance(value, int | float):
+                return max(0.0, min(1.0, float(value)))
+
+        # Generic utility/relevance scores
         for key in ("utility_score", "relevance_score", "answer_overlap"):
             value = chunk.get(key)
             if isinstance(value, int | float):

--- a/src/agenticlens/recommenders/rag_chunk_utility.py
+++ b/src/agenticlens/recommenders/rag_chunk_utility.py
@@ -94,7 +94,9 @@ class RAGChunkUtilityRecommender(BaseRecommender):
                     severity=Severity.WARNING,
                     tokens_saved=tokens_saved,
                     confidence=self._compute_confidence(
-                        scored_count, len(chunks), has_rich_signals,
+                        scored_count,
+                        len(chunks),
+                        has_rich_signals,
                     ),
                     quality_risk="low" if has_rich_signals else "medium",
                 )
@@ -112,9 +114,7 @@ class RAGChunkUtilityRecommender(BaseRecommender):
         return None
 
     @staticmethod
-    def _compute_confidence(
-        scored_count: int, total_chunks: int, has_rich_signals: bool
-    ) -> float:
+    def _compute_confidence(scored_count: int, total_chunks: int, has_rich_signals: bool) -> float:
         """Higher confidence when rich signals (reranker/embedding/citation) are present."""
         coverage = scored_count / max(total_chunks, 1)
         if has_rich_signals:

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -108,7 +108,9 @@ def _sample_recommendations() -> list[Recommendation]:
     return [
         Recommendation(
             title="Low-utility retrieved chunks",
-            description="Step 'Retriever' retrieved 2 chunks that appear unlikely to influence the answer.",
+            description=(
+                "Step 'Retriever' retrieved 2 chunks that appear unlikely to influence the answer."
+            ),
             severity=Severity.WARNING,
             tokens_saved=100,
             confidence=0.85,

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 from agenticlens.exporters import CSVExporter, JiraExporter, JSONExporter, MarkdownExporter
 from agenticlens.models import Metrics, Step, StepType, Workflow
+from agenticlens.models.enums import Severity
+from agenticlens.models.recommendation import Recommendation
 
 
 def _sample_workflow() -> Workflow:
@@ -100,3 +102,71 @@ def test_jira_exporter_posts_comment(mock_urlopen: MagicMock, tmp_path: Path) ->
     assert mock_urlopen.call_args.kwargs["timeout"] == 10
     assert out.exists()
     assert "AgenticLens" in out.read_text()
+
+
+def _sample_recommendations() -> list[Recommendation]:
+    return [
+        Recommendation(
+            title="Low-utility retrieved chunks",
+            description="Step 'Retriever' retrieved 2 chunks that appear unlikely to influence the answer.",
+            severity=Severity.WARNING,
+            tokens_saved=100,
+            confidence=0.85,
+            quality_risk="low",
+        ),
+    ]
+
+
+def test_markdown_exporter_includes_recommendations(tmp_path: Path) -> None:
+    out = tmp_path / "report.md"
+    MarkdownExporter().export(_sample_workflow(), out, recommendations=_sample_recommendations())
+
+    content = out.read_text(encoding="utf-8")
+    assert "## Optimization Recommendations" in content
+    assert "Low-utility retrieved chunks" in content
+    assert "Tokens Saved:** 100" in content
+    assert "Confidence:** 85%" in content
+    assert "Quality Risk:** low" in content
+
+
+def test_json_exporter_includes_recommendations(tmp_path: Path) -> None:
+    out = tmp_path / "workflow.json"
+    JSONExporter().export(_sample_workflow(), out, recommendations=_sample_recommendations())
+
+    data = json.loads(out.read_text())
+    assert "recommendations" in data
+    assert len(data["recommendations"]) == 1
+    assert data["recommendations"][0]["title"] == "Low-utility retrieved chunks"
+    assert data["recommendations"][0]["tokens_saved"] == 100
+
+
+def test_csv_exporter_writes_recommendations_file(tmp_path: Path) -> None:
+    out = tmp_path / "steps.csv"
+    CSVExporter().export(_sample_workflow(), out, recommendations=_sample_recommendations())
+
+    rec_path = tmp_path / "steps_recommendations.csv"
+    assert rec_path.exists()
+
+    with rec_path.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Low-utility retrieved chunks"
+    assert rows[0]["tokens_saved"] == "100"
+    assert rows[0]["severity"] == "warning"
+
+
+def test_exporters_work_without_recommendations(tmp_path: Path) -> None:
+    """Backward compatibility: exporters still work without recommendations."""
+    md_out = tmp_path / "report.md"
+    MarkdownExporter().export(_sample_workflow(), md_out)
+    assert "## Optimization Recommendations" not in md_out.read_text()
+
+    json_out = tmp_path / "workflow.json"
+    JSONExporter().export(_sample_workflow(), json_out)
+    data = json.loads(json_out.read_text())
+    assert "recommendations" not in data
+
+    csv_out = tmp_path / "steps.csv"
+    CSVExporter().export(_sample_workflow(), csv_out)
+    assert not (tmp_path / "steps_recommendations.csv").exists()

--- a/tests/test_recommender_rules.py
+++ b/tests/test_recommender_rules.py
@@ -202,3 +202,104 @@ def test_rag_chunk_utility_skips_when_no_answer_or_scores() -> None:
     )
 
     assert RAGChunkUtilityRecommender().evaluate(workflow, CONFIG) == []
+
+
+def test_rag_chunk_utility_uses_reranker_scores() -> None:
+    workflow = _workflow(
+        Step(
+            name="Retriever",
+            type=StepType.RETRIEVER,
+            metadata={
+                "avg_tokens_per_chunk": 60,
+                "retrieved_chunks": [
+                    {"text": "Relevant chunk", "reranker_score": 0.85},
+                    {"text": "Another relevant", "reranker_score": 0.72},
+                    {"text": "Low quality chunk", "reranker_score": 0.02},
+                    {"text": "Noise chunk", "reranker_score": 0.01},
+                ],
+            },
+        ),
+    )
+
+    recs = RAGChunkUtilityRecommender().evaluate(workflow, CONFIG)
+
+    assert len(recs) == 1
+    assert recs[0].tokens_saved == 120
+    assert recs[0].quality_risk == "low"
+    assert recs[0].confidence is not None and recs[0].confidence >= 0.65
+
+
+def test_rag_chunk_utility_uses_embedding_similarity() -> None:
+    workflow = _workflow(
+        Step(
+            name="Retriever",
+            type=StepType.RETRIEVER,
+            metadata={
+                "avg_tokens_per_chunk": 40,
+                "retrieved_chunks": [
+                    {"text": "Highly similar", "cosine_similarity": 0.92},
+                    {"text": "Low similarity", "cosine_similarity": 0.03},
+                    {"text": "Very low", "embedding_similarity": 0.01},
+                ],
+            },
+        ),
+    )
+
+    recs = RAGChunkUtilityRecommender().evaluate(workflow, CONFIG)
+
+    assert len(recs) == 1
+    assert recs[0].tokens_saved == 80
+    assert recs[0].quality_risk == "low"
+
+
+def test_rag_chunk_utility_uses_citation_signals() -> None:
+    workflow = _workflow(
+        Step(
+            name="Retriever",
+            type=StepType.RETRIEVER,
+            metadata={
+                "avg_tokens_per_chunk": 50,
+                "retrieved_chunks": [
+                    {"text": "Used chunk", "cited": True},
+                    {"text": "Not cited 1", "cited": False},
+                    {"text": "Not cited 2", "cited": False},
+                    {"text": "Also cited", "referenced": True},
+                ],
+            },
+        ),
+    )
+
+    recs = RAGChunkUtilityRecommender().evaluate(workflow, CONFIG)
+
+    assert len(recs) == 1
+    assert recs[0].tokens_saved == 100
+    assert recs[0].quality_risk == "low"
+
+
+def test_rag_chunk_utility_mixed_signals_prefer_explicit() -> None:
+    """When explicit signals exist, word-overlap fallback is not used."""
+    workflow = _workflow(
+        Step(
+            name="Retriever",
+            type=StepType.RETRIEVER,
+            metadata={
+                "avg_tokens_per_chunk": 50,
+                "retrieved_chunks": [
+                    {"text": "Good chunk with overlap words", "reranker_score": 0.9},
+                    {"text": "Bad chunk despite overlap words", "reranker_score": 0.01},
+                    {"text": "Another bad one", "reranker_score": 0.02},
+                ],
+            },
+        ),
+        Step(
+            name="Final Response",
+            type=StepType.FINAL_RESPONSE,
+            metadata={"final_answer": "overlap words in the answer"},
+        ),
+    )
+
+    recs = RAGChunkUtilityRecommender().evaluate(workflow, CONFIG)
+
+    assert len(recs) == 1
+    # Reranker scores should be used, not word overlap
+    assert recs[0].quality_risk == "low"


### PR DESCRIPTION
### Summary

Enhances the `RAGChunkUtilityRecommender` to support multiple signal types beyond the existing word-overlap heuristic, and adds recommendation output to exporters (JSON, CSV, Markdown).

### What's New

**RAG Scoring Signals (priority order):**

| Signal | Fields | Source |
|--------|--------|--------|
| Citation | `cited`, `used`, `referenced` | App logic |
| Reranker | `reranker_score`, `rerank_score`, `cross_encoder_score` | Cross-encoder models |
| Embedding | `embedding_similarity`, `cosine_similarity`, `semantic_score` | Vector search |
| Generic | `utility_score`, `relevance_score` | Custom scoring |
| Fallback | Word-overlap vs final answer | Automatic |

**Key behaviors:**
- Rich signals (citation/reranker/embedding) → higher confidence (0.65–0.95), quality risk = "low"
- Generic/fallback signals → standard confidence (0.45–0.85), quality risk = "medium"
- Word-overlap fallback is only used when NO chunk has any explicit score (never mixes signal types)
- Bool excluded from numeric checks (`isinstance(value, (int, float)) and not isinstance(value, bool)`)

**Exporter enhancements:**
- `MarkdownExporter` — adds "Optimization Recommendations" section
- `JSONExporter` — includes `"recommendations"` array in output
- `CSVExporter` — writes a `*_recommendations.csv` file alongside step data
- `BaseExporter` — updated interface with optional `recommendations` param
- All backward-compatible (param is optional)

### Files Changed

- rag_chunk_utility.py — enhanced scoring + two-pass logic
- base.py — updated interface
- json_exporter.py — recommendations support
- csv_exporter.py — recommendations support
- markdown_exporter.py — recommendations support
- jira_exporter.py — signature updated (ignores recommendations)
- test_recommender_rules.py — 4 new tests for signal types
- test_exporters.py — 4 new tests for recommendation output
- rag_scoring_demo.py — full example with all signal types
- export_demo.py — updated to include recommendations
- rag-chunk-utility.md — comprehensive reference guide
- README.md — expanded RAG section + export usage
- mkdocs.yml — added docs page

---