### PR TITLE
docs: update roadmap — mark exporters and RAG scoring as completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,6 @@ src/agenticlens/
 
 Near-term priorities:
 
-- ~~richer RAG utility scoring with citation, reranker, and embedding signals~~ ✅
 - model-tier mismatch detection
 - prompt caching opportunity detection
 - integrations for LangChain, LangGraph, LiteLLM, and OpenAI Agents SDK

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ src/agenticlens/
 
 Near-term priorities:
 
-- richer RAG utility scoring with citation, reranker, and embedding signals
+- ~~richer RAG utility scoring with citation, reranker, and embedding signals~~ ✅
 - model-tier mismatch detection
 - prompt caching opportunity detection
 - integrations for LangChain, LangGraph, LiteLLM, and OpenAI Agents SDK

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,10 @@
 - [x] GitHub Actions CI pipeline
 - [x] Recommendation engine heuristic rules (repeated system prompt, excessive chunks, long history, duplicate tool calls)
 - [x] CLI `profile`/`report`/`analyze` business logic
-- [ ] Documentation structure (MkDocs)
+- [x] Documentation structure (MkDocs)
+- [x] Markdown and Jira exporters
+- [x] RAG chunk-utility scoring (citation, reranker, embedding signals)
+- [x] Recommendation output in exporters (JSON, CSV, Markdown)
 
 ## Post-MVP
 
@@ -22,7 +25,6 @@ See "Future Roadmap" in [AgenticLens_Spec.md](AgenticLens_Spec.md):
 
 - LangGraph / CrewAI / OpenAI Agents SDK integrations
 - MCP server-level token attribution
-- RAG chunk-utility scoring
 - Automated prompt compression
 - Context utilization metrics
 - Evaluation framework (quality vs. cost)


### PR DESCRIPTION
- Mark MkDocs, Markdown/Jira exporters, RAG chunk-utility scoring, and recommendation output in exporters as done
- Remove RAG chunk-utility from Post-MVP (now in MVP)
- Strike through completed item in README roadmap

