### PR TITLE
Add contributor docs, Makefile automation, and evidence provenance roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+## AgenticLens Development Reference
+
+## Build and Run
+
+- Install: `make install` (runs `uv sync --extra dev --extra docs`)
+- Test: `make test` or `make check` (lint + format + typecheck + test)
+- Lint: `make lint`
+- Type check: `make typecheck`
+- Build docs: `make docs`
+- CLI: `uv run agenticlens <command>`
+
+## Code Style
+
+- Strict typing (mypy strict mode, Python 3.10+)
+- Line length: 100
+- Ruff rules: E, F, I, UP, B, SIM, N
+- Per-file ignores: E501 for `html_report.py`
+- One purpose per file (separation of concerns)
+- Evidence-backed: findings must identify measurements, thresholds, and trace
+  evidence on which they are based
+
+## Repo Map
+
+| Path | Purpose |
+|------|---------|
+| `src/agenticlens/profiler/` | Workflow and step profiling (`profile()`, `step()`) |
+| `src/agenticlens/instrumentation/` | Structured Run/Span tracing, payload redaction |
+| `src/agenticlens/analysis/` | Memory and retry diagnostics |
+| `src/agenticlens/analyzers/` | Analyzer implementations |
+| `src/agenticlens/comparison/` | Repeated-run statistics, regression reports |
+| `src/agenticlens/config/` | Pricing data, settings, configuration |
+| `src/agenticlens/evaluation/` | Test cases, suites, evaluators, and scoring |
+| `src/agenticlens/exporters/` | JSON, CSV, Markdown, Jira exports |
+| `src/agenticlens/metrics/` | Cost and performance calculation |
+| `src/agenticlens/models/` | Pydantic data models (Workflow, Step, ChaosEvent) |
+| `src/agenticlens/providers/` | Provider response usage extraction (OpenAI, Anthropic) |
+| `src/agenticlens/recommenders/` | Rule-based optimization suggestions |
+| `src/agenticlens/reports/` | Trace inspection rendering |
+| `src/agenticlens/cli/` | Typer CLI and Rich rendering |
+| `src/agenticlens/utils/` | Shared utilities |
+| `schemas/` | Versioned JSON Schemas (trace, finding, report) |
+| `tests/` | Pytest test suite |
+| `docs/` | MkDocs documentation source |
+| `Makefile` | Local dev automation |
+
+## Entry Points
+
+- Console script: `agenticlens` → `cli/main.py:app`
+- Profiling API: `from agenticlens import profile, step`
+- Analysis CLI: `agenticlens analyze <workflow.json>`
+
+## Module Boundaries
+
+- `exporters/` must not import from `cli/`
+- `models/` must not import from `recommenders/` or `analysis/`
+- `providers/` extracts usage data only — no analysis logic
+- `recommenders/` reads models and metrics, produces findings
+- `cli/` composes everything for user-facing commands
+
+## Adding a New Recommender
+
+1. Create `src/agenticlens/recommenders/my_recommender.py`
+2. Implement the recommender (takes a Workflow, returns findings)
+3. Register in `DEFAULT_RECOMMENDERS` in `recommenders/engine.py`
+4. Add tests in `tests/`
+5. Every finding must include source evidence (step/span reference)
+
+## Schema Versioning
+
+- Schemas live in `schemas/` and are included in the wheel via `force-include`
+- Trace, finding, and comparison-report schemas are versioned independently
+- Additive changes preferred; breaking changes require version bump
+
+## Pre-push Checklist
+
+Run `make check` before every push. It runs: lint → format-check → typecheck → test.

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,70 @@
+# CI Readiness — Pre-push Checklist
+
+Run these checks locally before every push or PR.
+
+## Docs-only shortcut
+
+If your diff only touches `.md` files or `docs/` content, skip code checks.
+Verify with:
+
+```bash
+git status --short
+```
+
+## Required checks (all code changes)
+
+```bash
+make check
+```
+
+This runs lint → format-check → typecheck → test in sequence. If any step
+fails, fix it before pushing.
+
+Or run steps individually:
+
+1. **Clean tree** — no accidental untracked files, no `.env` or secrets
+
+   ```bash
+   git status --short
+   ```
+
+2. **Lint**
+
+   ```bash
+   make lint
+   ```
+
+3. **Format**
+
+   ```bash
+   make format-check
+   ```
+
+   If it fails: `make format && make format-check`
+
+4. **Type check**
+
+   ```bash
+   make typecheck
+   ```
+
+5. **Test**
+
+   ```bash
+   make test
+   ```
+
+## When to run full coverage
+
+Run `make test-cov` instead of `make test` when:
+
+- Core modules changed (`models/`, `instrumentation/`, `profiler/`)
+- Recommender engine or pipeline changed
+- Schema files changed
+- New exporters or providers added
+- Cross-cutting refactor touching 3+ modules
+
+## CI parity
+
+The GitHub Actions CI workflow runs the same checks across Python 3.10–3.14
+using `uv`. If `make check` passes locally, CI should pass too.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help install lint format format-check typecheck test test-cov clean build docs
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install dependencies (dev extras)
+	uv sync --extra dev --extra docs
+
+lint: ## Run ruff linter
+	uv run ruff check .
+
+format: ## Auto-format code
+	uv run ruff format .
+
+format-check: ## Check formatting without changes
+	uv run ruff format --check .
+
+typecheck: ## Run mypy type checking
+	uv run mypy
+
+test: ## Run tests
+	uv run pytest
+
+test-cov: ## Run tests with coverage
+	uv run pytest --cov --cov-report=term-missing
+
+clean: ## Remove build artifacts
+	rm -rf dist/ build/ *.egg-info src/*.egg-info .mypy_cache .pytest_cache .ruff_cache site/
+
+build: ## Build package distributions
+	uv run python -m build
+
+docs: ## Build documentation
+	uv run mkdocs build
+
+docs-serve: ## Serve docs locally
+	uv run mkdocs serve
+
+check: lint format-check typecheck test ## Run all quality gates

--- a/README.md
+++ b/README.md
@@ -1009,21 +1009,21 @@ The `compare` command accepts either one JSON trace file or a directory of
 
 ## Development
 
-Install development dependencies:
+A `Makefile` provides shorthand for common tasks:
 
 ```bash
-uv sync --extra dev
+make install     # install dev dependencies
+make check       # run all quality gates (lint + format + typecheck + test)
+make test-cov    # tests with coverage report
+make docs        # build documentation
+make help        # list all available targets
 ```
 
-Run the test suite:
+Or run individual steps:
 
 ```bash
+uv sync --extra dev --extra docs
 uv run pytest
-```
-
-Run linting, formatting, and type checks:
-
-```bash
 uv run ruff check .
 uv run ruff format .
 uv run mypy
@@ -1059,6 +1059,12 @@ schemas/           versioned trace, finding, and report JSON Schemas
 
 Near-term priorities:
 
+- **evidence provenance** — every recommendation points to source step/span,
+  timestamp, confidence, and derived reasoning
+- **next-best-analysis recommendations** — suggest what to inspect next based
+  on workflow shape
+- **OpenTelemetry export** — traces flow into Grafana/Jaeger/OTel-native systems
+- **import-layer enforcement** — CI prevents architectural drift across modules
 - context-duplication detection
 - retry classification and triggering-failure association
 - experiment manifests and confidence intervals

--- a/agenticlens-roadmap.md
+++ b/agenticlens-roadmap.md
@@ -200,6 +200,31 @@ diagnostics, and baseline comparison.
 - privacy defaults and redaction behavior are documented
 - performance overhead is measured
 
+## v0.2.x — Evidence Provenance & Operational Intelligence
+
+### Objective
+
+Make every finding and recommendation traceable to its source evidence, and add
+intelligent guidance for what analysis to run next.
+
+### Planned deliverables
+
+- first-class `Evidence` object on all findings and recommendations (source
+  step/span, timestamp, confidence, derived reasoning chain)
+- "next best analysis" recommendations — suggest what the user should inspect
+  next based on workflow shape and current findings
+- OpenTelemetry trace export — let agenticlens traces flow into
+  Grafana/Jaeger/OTel-native systems
+- import-layer enforcement in CI — prevent architectural drift as the package
+  grows (e.g., `exporters/` must not import from `cli/`)
+
+### Completion criteria
+
+- every recommendation includes a provenance reference to its source spans
+- next-step suggestions are generated for workflows with 3+ analysis findings
+- OTel spans are emitted for profiled workflows when configured
+- CI rejects forbidden cross-module imports
+
 ## v0.3 — Evaluation Foundation
 
 ### Objective
@@ -285,6 +310,12 @@ recorded evidence.
 - anomaly detection
 - faulty-step and faulty-agent attribution
 - incident timeline reconstruction
+- investigation-style narratives on top of recommendations — root-cause
+  explanations of waste, retries, handoff bloat, or tool inefficiency
+- richer CLI subcommands for inspection (`inspect`, `compare`, `trace show`,
+  `report explain`)
+- analysis guardrails (budget limits, recursion-depth caps, stagnation
+  detection for automated analyzers)
 
 ### Completion criteria
 


### PR DESCRIPTION
## Summary

This PR improves contributor ergonomics and clarifies the near-term direction of AgenticLens.

## Changes

### Repo automation
- add `Makefile` for install/lint/format/typecheck/test/docs flows

### Contributor guidance
- add `AGENTS.md`
- add `CI.md`

### Docs and roadmap
- update `README.md` development guidance to use `make` targets
- add near-term priorities to the roadmap section in `README.md`
- extend `agenticlens-roadmap.md` with a new near-term milestone for:
  - evidence provenance
  - next-best-analysis recommendations
  - OpenTelemetry export
  - import-layer enforcement

## Notes

The new contributor docs were reviewed and corrected to match the actual codebase:
- analysis is documented as CLI usage, not a nonexistent public API
- `evaluation/` is described as implemented
- recommender registration points to `DEFAULT_RECOMMENDERS`
- module boundary guidance reflects current structure

## Validation

- `make check`