### PR TITLE
Ship trace comparison and live evaluation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented here.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## 0.4.0 - 2026-08-08
+
+### Added
+
+- Markdown trace and comparison reports, including CLI support via
+  `agenticlens inspect --save` and `agenticlens compare --format md`.
+- Minimum-sample guidance for repeated-run comparison, plus `--min-samples`
+  enforcement in the CLI for CI-friendly under-sampling checks.
+- First-class `Evidence` objects on findings and recommendations, with
+  provenance carried through analysis and reporting.
+- Duplicate-context detection, retry attribution, retry outcome
+  classification, and next-best-analysis suggestions for structured traces.
+- Additional deterministic evaluation checks for JSON Schema validation,
+  required output fields, required tool arguments, and turn-count thresholds.
+- `BusinessRuleEvaluator` and trusted live evaluation targets for Python and
+  HTTP workflows via `evaluate-live`.
+- Architecture import-layer enforcement tests and a runnable live-evaluation
+  example covering structured-output checks.
+
+### Changed
+
+- The finding schema now reflects evidence as structured arrays rather than an
+  untyped object, matching shipped runtime artifacts.
+- Trace analysis no longer mutates the input run while computing retry
+  attribution.
+- Documentation, examples, and roadmap details now match the shipped trace,
+  comparison, and evaluation feature surface.
+
 ## 0.3.0 - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ candidate exceeds configured regression limits.
 
 AgenticLens can now evaluate versioned test suites against recorded outputs and
 traces. Deterministic checks cover answer content, required or forbidden tool
-use, latency, and cost. The resulting evidence can be exported as JSON, rendered
-as a standalone HTML report, and enforced as a release gate in CI.
+use, required tool arguments, structured JSON output, required output fields,
+turn counts, latency, and cost. The resulting evidence can be exported as JSON,
+rendered as a standalone HTML report, and enforced as a release gate in CI.
+Trusted live Python and HTTP targets can also be executed directly against the
+same suite.
 
 ## Architecture
 
@@ -180,6 +183,7 @@ research trace API is experimental and may evolve before a stable 1.0 release.
 | Repeated-run regression comparison | Implemented, experimental |
 | Unified evaluator SDK and versioned test suites | Implemented, experimental |
 | Provider-neutral custom and LLM-judge adapters | Implemented, experimental |
+| Live Python and HTTP evaluation targets | Implemented, experimental |
 | Quality, tool-use, latency, and cost release gates | Implemented, experimental |
 | Standalone evaluation HTML report | Implemented, experimental |
 | Statistical significance testing | Planned |
@@ -190,7 +194,8 @@ research trace API is experimental and may evolve before a stable 1.0 release.
 
 Versioned YAML or JSON suites turn expected agent behavior into executable
 acceptance criteria. AgenticLens checks response content, required and forbidden
-tools, end-to-end latency, and estimated cost against recorded run traces.
+tools, required tool arguments, structured JSON output, required output fields,
+turn counts, end-to-end latency, and estimated cost against recorded run traces.
 
 ```bash
 agenticlens evaluate suite.yaml samples.json \
@@ -206,6 +211,19 @@ agenticlens gate evaluation.json \
 The evaluation command produces machine-readable JSON and an optional
 standalone HTML report. The gate command returns exit status `2` when a
 configured release threshold fails, making it suitable for CI.
+
+Run a trusted live target directly:
+
+```bash
+agenticlens evaluate-live suite.yaml \
+  --target-kind python \
+  --target examples/live_evaluation_demo.py:run_case \
+  --save evaluation-live.json
+```
+
+`evaluate-live` is intentionally powerful. Python targets execute local code
+and HTTP targets can reach arbitrary URLs, so suite files and live targets
+should be treated as trusted developer-controlled inputs.
 
 The offline LangGraph pitch demonstration exercises the complete workflow:
 
@@ -353,7 +371,8 @@ Each run can report:
 
 Parent-child span relationships preserve execution structure, such as a retry
 that occurred inside a failed tool call. Saved traces are validated for
-duplicate IDs, missing parents, and self-parent relationships.
+duplicate IDs, missing parents, self-parent relationships, and cyclic parent
+graphs.
 
 Inspect a saved trace:
 
@@ -362,7 +381,14 @@ agenticlens inspect run.json
 ```
 
 The terminal report includes a run summary, nested span tree, token and latency
-distributions, errors, retries, and deterministic findings.
+distributions, errors, retries, deterministic findings, and next-best-analysis
+guidance when findings indicate a likely follow-up investigation path.
+
+Save a Markdown trace report:
+
+```bash
+agenticlens inspect run.json --save trace-report.md
+```
 
 ### Trace lifecycle
 
@@ -445,8 +471,9 @@ finding containing:
 - severity and confidence
 - exact span IDs that contributed to the finding
 
-These findings identify measurable overhead. They do not yet determine whether
-memory was relevant or classify retries as useful, wasteful, or unresolved.
+These findings identify measurable overhead. Retry findings also retain
+evidence about likely triggering failures and whether a retry appears to have
+recovered, failed, or remained unresolved.
 
 ## Repeated-Run Comparison
 
@@ -494,12 +521,26 @@ agenticlens compare results/baseline results/candidate \
   --format csv
 ```
 
+Use Markdown for a review-friendly report:
+
+```bash
+agenticlens compare results/baseline results/candidate \
+  --save comparison.md \
+  --format md
+```
+
 Use `--fail-on-regression` to return a nonzero exit status in CI:
 
 ```bash
 agenticlens compare results/baseline results/candidate \
   --regression-threshold 0.05 \
   --fail-on-regression
+```
+
+Require a minimum cohort size before trusting a comparison:
+
+```bash
+agenticlens compare results/baseline results/candidate --min-samples 5
 ```
 
 Current comparisons are descriptive. They do not claim statistical
@@ -661,12 +702,13 @@ These runtime objects emit AI-native events such as `workflow.run`,
 | Metrics | Prompt tokens, completion tokens, total tokens, latency, TPS, cost |
 | Diagnostics | Memory-share and retry-overhead findings with span-level evidence |
 | Comparison | Repeated runs, P95, variability, cost per success, regression detection |
+| Evaluation | Structured-output, tool-argument, and turn-count checks |
 | Privacy | Opt-in payload capture with recursive redaction |
 | Providers | OpenAI and Anthropic response usage extraction |
 | Costing | User overrides, cached live LiteLLM pricing, bundled fallback pricing |
 | Recommendations | Repeated prompts, excessive chunks, low-utility chunks, long history, duplicate tool calls |
 | Budget impact | Dollar-per-run and monthly savings projections |
-| CLI | `profile`, `report`, `analyze`, `inspect`, and `compare` commands |
+| CLI | `profile`, `report`, `analyze`, `inspect`, `compare`, `evaluate`, `evaluate-live`, and `gate` |
 | Export | Workflow reports, run traces, JSON, CSV, Markdown, and Jira |
 | Schemas | Versioned trace, finding, and comparison-report JSON Schemas |
 | Tooling | pytest, Ruff, mypy, GitHub Actions |
@@ -876,6 +918,7 @@ Other examples:
 - `examples/multiagent_token_optimization_demo.py`
 - `examples/reference_workflows/langgraph_supervisor.py` — offline LangGraph supervisor
 - `examples/export_demo.py` — export to Markdown and Jira
+- `examples/live_evaluation_demo.py` — trusted live Python target for `evaluate-live`
 - `examples/rag_scoring_demo.py` — RAG chunk utility with reranker/embedding/citation signals
 
 Some examples call real provider APIs and require provider API keys.
@@ -964,6 +1007,12 @@ Inspect a saved run trace:
 uv run agenticlens inspect run.json
 ```
 
+Save a Markdown trace report:
+
+```bash
+uv run agenticlens inspect run.json --save trace.md
+```
+
 Compare baseline and candidate traces:
 
 ```bash
@@ -978,6 +1027,35 @@ uv run agenticlens compare results/baseline results/candidate \
   --fail-on-regression
 ```
 
+Save a Markdown comparison report and enforce sample size:
+
+```bash
+uv run agenticlens compare results/baseline results/candidate \
+  --save comparison.md \
+  --format md \
+  --min-samples 5
+```
+
+Evaluate recorded samples:
+
+```bash
+uv run agenticlens evaluate suite.yaml samples.json --html evaluation.html
+```
+
+Run a trusted live Python target:
+
+```bash
+uv run agenticlens evaluate-live suite.yaml \
+  --target-kind python \
+  --target examples/live_evaluation_demo.py:run_case
+```
+
+Apply a release gate:
+
+```bash
+uv run agenticlens gate evaluation.json --min-pass-rate 0.95
+```
+
 ### Command summary
 
 | Command | Purpose |
@@ -987,6 +1065,9 @@ uv run agenticlens compare results/baseline results/candidate \
 | `analyze` | Run optimization recommenders against a workflow |
 | `inspect` | Render a run trace, span tree, distributions, and findings |
 | `compare` | Compare baseline and candidate trace files or directories |
+| `evaluate` | Score recorded outputs and traces against a test suite |
+| `evaluate-live` | Run a trusted live Python or HTTP target against a suite |
+| `gate` | Enforce release thresholds from an evaluation report |
 
 The `compare` command accepts either one JSON trace file or a directory of
 `*.json` traces for each condition.
@@ -996,14 +1077,13 @@ The `compare` command accepts either one JSON trace file or a directory of
 - The research trace API and workflow profiler use separate artifact types.
 - Trace-span cost must currently be recorded by the caller.
 - Memory findings measure consumption, not semantic relevance or contribution.
-- Retry findings measure overhead but do not classify recovery outcomes.
-- Context-duplication detection is not implemented yet.
 - Comparisons do not calculate confidence intervals or significance tests yet.
 - No built-in task-quality evaluator is available yet.
 - Model-swap recommendations estimate cost and do not guarantee quality.
 - Live pricing uses a community-maintained feed that may lag provider changes.
 - Default redaction cannot guarantee removal of every domain-specific secret or
   personal identifier.
+- `evaluate-live` assumes trusted targets and suite definitions.
 - Framework adapters, OpenTelemetry export, and a local dashboard remain
   planned.
 
@@ -1059,16 +1139,10 @@ schemas/           versioned trace, finding, and report JSON Schemas
 
 Near-term priorities:
 
-- **evidence provenance** — every recommendation points to source step/span,
-  timestamp, confidence, and derived reasoning
-- **next-best-analysis recommendations** — suggest what to inspect next based
-  on workflow shape
 - **OpenTelemetry export** — traces flow into Grafana/Jaeger/OTel-native systems
-- **import-layer enforcement** — CI prevents architectural drift across modules
-- context-duplication detection
-- retry classification and triggering-failure association
+- **AIOS conformance tooling** — validate workflows against normative spec rules
 - experiment manifests and confidence intervals
-- evaluation test cases, suites, evaluators, and scores
+- evaluation dataset management
 - automatic pricing resolution for research trace spans
 - prompt caching opportunity detection
 - integrations for LangChain, LangGraph, LiteLLM, and OpenAI Agents SDK

--- a/agenticlens-roadmap.md
+++ b/agenticlens-roadmap.md
@@ -1,5 +1,33 @@
 # AgenticLens Product Roadmap
 
+## Release Status
+
+Shipped PyPI releases: `0.1.1` → `0.1.2` → `0.2.0` → `0.3.0` → `0.4.0`
+(current, 2026-08-08) — see [CHANGELOG.md](CHANGELOG.md). The version labels
+below are this roadmap's release-plan sequence, not PyPI tags — shipped
+`0.4.0` already covers most of planned `v0.2` and `v0.3`, and pulled pieces
+forward from `v0.5` and `v1.0`.
+
+- **v0.2** ✅ Delivered in `0.3.0` — Trace and Comparison Foundation
+  (hierarchical tracing, cyclic-parent detection, retry attribution,
+  regression detection, baseline/candidate comparison, and Markdown reports)
+- **v0.2.x** 🚧 Planned — Evidence Provenance & Operational Intelligence
+  (`Evidence` objects, OTel export, import-layer enforcement, AIOS conformance
+  CLI)
+- **v0.3** 🏗️ Mostly complete — Evaluation Foundation (evaluator framework,
+  deterministic checks, custom/LLM-judge evaluators, release gates,
+  `evaluate`/`gate` CLI, and live agent targets); judge calibration and
+  dataset management still open
+- **v0.4** 🚧 Planned — Experiments and Statistical Comparison
+- **v0.5** 🚧 Planned — Advanced Evaluation and Diagnosis (semantic/safety/RAG
+  scoring partially pulled forward into `v0.3`)
+- **v0.6** 🚧 Planned — Test-Suite and Dataset Management
+- **v0.7** 🚧 Planned — ModelFit
+- **v0.8** 🚧 Planned — Advisory Runtime Routing
+- **v0.9** 🚧 Planned — Optimization Intelligence
+- **v1.0** 🚧 Planned — Production and Enterprise Readiness (release gates
+  partially pulled forward into `v0.3`)
+
 ## Purpose
 
 This roadmap defines the planned evolution of AgenticLens from a local workflow
@@ -98,7 +126,8 @@ The following capabilities are implemented in the current development line.
 - RAG chunk-utility analysis
 - long-history detection
 - duplicate tool-call detection
-- multi-agent handoff analysis
+- multi-agent handoff analysis, including handoff-bloat findings
+- agent-aware summaries in CLI analysis output
 - model-tier cost comparison
 - agentic-chaos impact findings
 
@@ -124,6 +153,24 @@ The following capabilities are implemented in the current development line.
 - configurable regression detection
 - JSON and CSV comparison reports
 - CI-compatible regression exit status
+
+### Evaluation and release gates
+
+- versioned YAML and JSON test suites (`TestSuite`, `TestCase`)
+- a unified, provider-neutral evaluator contract (`Evaluator`, `EvaluationContext`,
+  `Score`, `EvaluatorRegistry`)
+- built-in deterministic checks: exact match, required-substring match, required
+  and forbidden tool calls, latency threshold, cost threshold
+- custom evaluators via `CallableEvaluator`, and model-based judges via
+  `LLMJudgeEvaluator`, sharing one normalized score contract
+- evaluation against recorded samples and their AgenticLens traces (not yet
+  live Python or HTTP agent invocation)
+- JSON and standalone HTML evaluation reports
+- configurable release gates on pass rate, average score, failed-case count,
+  average latency, and total cost, with CI-friendly exit codes
+- `evaluate` and `gate` CLI commands
+- a deterministic, offline LangGraph reference workflow demonstrating tracing,
+  evaluation, and release-gate output together
 
 ### Artifact contracts
 
@@ -176,21 +223,20 @@ diagnostics, and baseline comparison.
 - raw token, latency, cost, retry, and tool metrics
 - payload redaction
 - memory and retry findings
+- cyclic parent detection
+- retry attribution and retry outcome classification
+- duplicated-context detection
 - repeated-run statistics
 - baseline-versus-candidate regression detection
+- minimum-sample guidance in comparison reports
 - trace inspection and comparison CLI commands
-- JSON and CSV comparison exports
+- JSON, CSV, and Markdown comparison exports
+- Markdown trace reports
 - versioned research schemas
 
 ### Remaining work
 
-- detect cyclic parent relationships
-- associate retry spans with triggering failures
-- classify retry outcomes
-- detect duplicated context
 - measure instrumentation overhead
-- add minimum-sample guidance to comparison reports
-- add Markdown trace and comparison reports
 
 ### Completion criteria
 
@@ -198,7 +244,7 @@ diagnostics, and baseline comparison.
 - existing profiler APIs remain compatible
 - comparison results reproduce from saved traces
 - privacy defaults and redaction behavior are documented
-- performance overhead is measured
+- [ ] performance overhead is measured
 
 ## v0.2.x — Evidence Provenance & Operational Intelligence
 
@@ -207,16 +253,19 @@ diagnostics, and baseline comparison.
 Make every finding and recommendation traceable to its source evidence, and add
 intelligent guidance for what analysis to run next.
 
-### Planned deliverables
+### Delivered so far
 
-- first-class `Evidence` object on all findings and recommendations (source
+- first-class `Evidence` object on findings and recommendations (source
   step/span, timestamp, confidence, derived reasoning chain)
 - "next best analysis" recommendations — suggest what the user should inspect
   next based on workflow shape and current findings
-- OpenTelemetry trace export — let agenticlens traces flow into
-  Grafana/Jaeger/OTel-native systems
 - import-layer enforcement in CI — prevent architectural drift as the package
   grows (e.g., `exporters/` must not import from `cli/`)
+
+### Remaining planned deliverables
+
+- OpenTelemetry trace export — let agenticlens traces flow into
+  Grafana/Jaeger/OTel-native systems
 - AIOS conformance tooling in the CLI — commands such as
   `agenticlens validate workflow.json` and
   `agenticlens conformance --version 0.4 workflow.json`, with normative rules,
@@ -224,12 +273,12 @@ intelligent guidance for what analysis to run next.
 
 ### Completion criteria
 
-- every recommendation includes a provenance reference to its source spans
-- next-step suggestions are generated for workflows with 3+ analysis findings
-- OTel spans are emitted for profiled workflows when configured
-- CI rejects forbidden cross-module imports
-- conformance reports clearly distinguish AIOS-defined pass/fail rules from
-  AgenticLens-specific presentation and CLI behavior
+- [x] every recommendation includes a provenance reference to its source spans
+- [x] next-step suggestions are generated from current findings
+- [ ] OTel spans are emitted for profiled workflows when configured
+- [x] CI rejects forbidden cross-module imports
+- [ ] conformance reports clearly distinguish AIOS-defined pass/fail rules from
+      AgenticLens-specific presentation and CLI behavior
 
 ## v0.3 — Evaluation Foundation
 
@@ -238,35 +287,48 @@ intelligent guidance for what analysis to run next.
 Evaluate task outcomes and execution requirements using versioned, reusable test
 suites.
 
-### Planned deliverables
+### Delivered
 
-- `TestCase` and `TestSuite` models
-- `Evaluator`, `EvaluationContext`, and `Score` interfaces
-- YAML and JSON test-suite loading
-- evaluator registration
-- native Python and HTTP targets
-- JSON and Markdown evaluation reports
-- evaluator and suite version capture
+- `TestCase` and `TestSuite` models with versioned YAML/JSON loading
+- `Evaluator`, `EvaluationContext`, `Score`, and `EvaluatorRegistry` interfaces
+- built-in deterministic checks: exact match, required-substring match,
+  required/forbidden tools, JSON Schema validation, required fields,
+  required tool arguments, turn-count threshold, latency threshold, and cost
+  threshold
+- `CallableEvaluator` for custom Python rules, semantic, safety, and RAG
+  checks, `BusinessRuleEvaluator`, and `LLMJudgeEvaluator` for model-based
+  judgments, on one shared score contract
+- JSON and standalone HTML evaluation reports (HTML in place of the
+  originally planned Markdown report)
+- configurable release gates (pass rate, average score, failed cases,
+  latency, cost) with CI-friendly exit codes, via the `evaluate` and `gate`
+  CLI commands
+- live Python and HTTP evaluation targets via `evaluate-live`
+- a deterministic, offline LangGraph reference workflow demonstrating the
+  full trace-to-evaluation-to-gate path
 
-### Initial deterministic evaluators
+This pulled forward parts of the semantic, safety, RAG, and LLM-judge scoring
+originally planned for [v0.5](#v05--advanced-evaluation-and-diagnosis), and
+part of the release-gate concept originally planned for
+[v1.0](#v10--production-and-enterprise-readiness), via the shared evaluator
+contract rather than as separate subsystems.
 
-- exact match
-- contains match
-- JSON Schema validation
-- required fields
-- required and forbidden tools
-- tool-argument validation
-- latency threshold
-- cost threshold
-- turn-count threshold
-- custom business rules
+### Remaining work
+
+- built-in provider clients for LLM-judge calls (applications currently
+  supply the model call themselves)
+- asynchronous and batched evaluation execution
+- judge calibration reports and statistical confidence intervals
+- evaluation dataset management
+- automatic framework event adapters beyond the LangGraph reference demo
 
 ### Completion criteria
 
-- one Python agent and one HTTP agent can run the same suite
-- every score identifies its evaluator and version
-- reports distinguish measured and estimated values
-- failed cases retain trace-level evidence
+- [x] every score identifies its evaluator and version
+- [x] reports distinguish measured and estimated values (evaluated scores vs.
+      unavailable/omitted cost and latency data)
+- [x] failed cases retain trace-level evidence
+- [x] one Python agent and one HTTP agent can run the same suite live
 
 ## v0.4 — Experiments and Statistical Comparison
 
@@ -470,6 +532,10 @@ deployment options.
 
 Integrations will be introduced after the trace and evaluation contracts are
 stable enough to map framework behavior consistently.
+
+A deterministic LangGraph example demonstrates tracing, evaluation, and
+release-gate output together (see [v0.3](#v03--evaluation-foundation)), but
+this is a reference demo, not a first-class, maintained integration package.
 
 Planned targets include:
 

--- a/docs/evaluation-and-release-gates.md
+++ b/docs/evaluation-and-release-gates.md
@@ -16,6 +16,9 @@ Each test case can define:
 
 - exact output or required output phrases
 - required and forbidden tool calls
+- required tool arguments
+- expected JSON output structure and required fields
+- maximum turn count
 - maximum end-to-end latency
 - maximum estimated cost
 - tags and application-specific metadata
@@ -88,6 +91,9 @@ safety classifiers, RAG metrics, and internal services.
 while leaving model selection, credentials, prompts, retries, and structured
 output handling under application control.
 
+`BusinessRuleEvaluator` is a named wrapper around trusted application logic for
+organization-specific pass/fail rules that do not need an LLM judge.
+
 ## Run an Evaluation
 
 ```bash
@@ -98,6 +104,60 @@ agenticlens evaluate suite.yaml samples.json \
 
 The JSON report is suitable for CI and further analysis. The standalone HTML
 report is suitable for demonstrations, release reviews, and team sharing.
+
+## Run a Trusted Live Target
+
+`evaluate-live` runs the same suite against a trusted live target instead of a
+pre-recorded sample file.
+
+Run a Python callable:
+
+```bash
+agenticlens evaluate-live suite.yaml \
+  --target-kind python \
+  --target examples/live_evaluation_demo.py:run_case \
+  --save evaluation-live.json
+```
+
+Run an HTTP target:
+
+```bash
+agenticlens evaluate-live suite.yaml \
+  --target-kind http \
+  --target http://localhost:8000/evaluate \
+  --save evaluation-live.json
+```
+
+Live targets are intentionally powerful developer-facing integrations. Python
+targets execute local code and HTTP targets can reach arbitrary URLs, so suite
+files and target definitions should be treated as trusted inputs.
+
+## Example Advanced Checks
+
+```yaml
+cases:
+  - id: support-answer
+    name: Structured support answer
+    input:
+      question: Where is my refund?
+    required_tools: ["lookup_refund"]
+    required_tool_arguments:
+      lookup_refund: ["order_id"]
+    output_json_schema:
+      type: object
+      required: ["answer", "meta"]
+      properties:
+        answer:
+          type: string
+        meta:
+          type: object
+          required: ["confidence"]
+    required_output_fields:
+      - meta.confidence
+    max_turns: 3
+    max_latency_ms: 1200
+    max_cost_usd: 0.02
+```
 
 ## Apply a Release Gate
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,8 @@ local, inspectable, and exportable so teams can compare workflows across version
 - [Export formats](export-formats.md)
 - [RAG chunk utility](rag-chunk-utility.md)
 - [Trace and comparison](trace-and-comparison.md)
+- [Evaluation and release gates](evaluation-and-release-gates.md)
+- [Multi-agent reference workflows](multi-agent-reference-workflows.md)
 - [Product roadmap](https://github.com/DeepAgentLabs/agenticlens/blob/main/agenticlens-roadmap.md)
 - [Research roadmap](https://github.com/DeepAgentLabs/agenticlens/blob/main/AgenticLens_Research_and_Development_Roadmap.md)
 
@@ -81,7 +83,7 @@ uv run agenticlens analyze workflow.json
 
 AgenticLens is early-stage open-source software. Workflow profiling, live and
 offline pricing, optimization recommendations, structured tracing, deterministic
-memory and retry findings, repeated-run comparison, CLI commands, and export
-formats are implemented. The trace and comparison APIs remain experimental.
-Evaluation suites, framework adapters, OpenTelemetry export, and the optional
-dashboard remain roadmap work.
+memory and retry findings, repeated-run comparison, evaluation suites, release
+gates, CLI commands, and export formats are implemented. The trace,
+comparison, and evaluation APIs remain experimental. Framework adapters,
+OpenTelemetry export, and the optional dashboard remain roadmap work.

--- a/docs/trace-and-comparison.md
+++ b/docs/trace-and-comparison.md
@@ -30,8 +30,15 @@ agenticlens inspect run.json
 ```
 
 The report includes a span tree, raw token and latency distributions, retry and tool-call
-counts, and deterministic memory/retry findings. Findings cite the exact spans and
-measurements that triggered them.
+counts, deterministic findings, and next-best-analysis guidance when findings suggest
+an obvious follow-up. Findings cite the exact spans and measurements that triggered
+them.
+
+Save a Markdown trace report:
+
+```bash
+agenticlens inspect run.json --save trace-report.md
+```
 
 ## Compare repeated runs
 
@@ -46,6 +53,16 @@ agenticlens compare results/baseline results/candidate \
 Use `--format csv` for tabular export and `--fail-on-regression` in CI. Comparisons report
 success rate, mean/median/P95 values, standard deviation, coefficient of variation,
 cost per successful task, and relative regressions.
+
+Use `--format md` for a review-friendly Markdown summary and `--min-samples` when a
+comparison should fail under CI if either cohort is too small:
+
+```bash
+agenticlens compare results/baseline results/candidate \
+  --format md \
+  --save comparison.md \
+  --min-samples 5
+```
 
 The comparison is descriptive. It does not claim statistical significance or causal
 attribution, particularly for small or uncontrolled samples.

--- a/examples/live_evaluation_demo.py
+++ b/examples/live_evaluation_demo.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from agenticlens.evaluation import PythonTarget, TestCase, TestSuite, run_live_suite
+
+
+def run_case(payload, *, case):
+    """Trusted Python target for `agenticlens evaluate-live`.
+
+    The callable returns the same structure expected by `EvaluationSample`
+    minus `case_id`, which AgenticLens supplies from the suite.
+    """
+    started = datetime.now(timezone.utc)
+    answer = {
+        "answer": f"Refund for order {payload['order_id']} is in progress.",
+        "meta": {"confidence": 0.94},
+    }
+    trace = {
+        "application_name": "live-demo",
+        "started_at": started.isoformat(),
+        "completed_at": (started + timedelta(milliseconds=35)).isoformat(),
+        "status": "succeeded",
+        "task_success": True,
+        "metadata": {"turn_count": 1, "case_name": case.name},
+        "spans": [
+            {
+                "name": "lookup refund",
+                "span_type": "tool_call",
+                "status": "succeeded",
+                "tool_name": "lookup_refund",
+                "estimated_cost_usd": 0.002,
+                "attributes": {"tool_args": {"order_id": payload["order_id"]}},
+            }
+        ],
+    }
+    return {"output": json.dumps(answer), "trace": trace}
+
+
+def main() -> None:
+    suite = TestSuite(
+        name="live-evaluation-demo",
+        version="1",
+        cases=[
+            TestCase(
+                id="refund-1",
+                name="Refund answer stays structured",
+                input={"order_id": "A123"},
+                required_tools=["lookup_refund"],
+                required_tool_arguments={"lookup_refund": ["order_id"]},
+                output_json_schema={
+                    "type": "object",
+                    "required": ["answer", "meta"],
+                    "properties": {
+                        "answer": {"type": "string"},
+                        "meta": {
+                            "type": "object",
+                            "required": ["confidence"],
+                        },
+                    },
+                },
+                required_output_fields=["meta.confidence"],
+                max_turns=1,
+                max_latency_ms=250,
+                max_cost_usd=0.01,
+            )
+        ],
+    )
+
+    report = run_live_suite(
+        suite,
+        PythonTarget(callable_path="examples/live_evaluation_demo.py:run_case"),
+    )
+    print(report.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agenticlens"
-version = "0.3.0"
+version = "0.4.0"
 description = "Profile, analyze, and optimize token consumption in LLM-powered applications and agentic workflows."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/schemas/finding.schema.json
+++ b/schemas/finding.schema.json
@@ -12,6 +12,21 @@
     "severity": {"type": "string"},
     "confidence": {"type": "number", "minimum": 0, "maximum": 1},
     "span_ids": {"type": "array", "items": {"type": "string"}},
-    "evidence": {"type": "object"}
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "confidence", "details"],
+        "properties": {
+          "source": {"type": "string", "minLength": 1},
+          "span_id": {"type": ["string", "null"]},
+          "timestamp": {"type": ["string", "null"], "format": "date-time"},
+          "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+          "reasoning": {"type": ["string", "null"]},
+          "details": {"type": "object"}
+        },
+        "additionalProperties": false
+      }
+    }
   }
 }

--- a/src/agenticlens/__init__.py
+++ b/src/agenticlens/__init__.py
@@ -2,7 +2,7 @@ from agenticlens.instrumentation import SpanHandle, trace
 from agenticlens.models.trace import Run, RunStatus, Span, SpanType
 from agenticlens.profiler import StepHandle, profile, step
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "Run",

--- a/src/agenticlens/analysis/__init__.py
+++ b/src/agenticlens/analysis/__init__.py
@@ -1,3 +1,4 @@
+from agenticlens.analysis.next_steps import next_best_analyses
 from agenticlens.analysis.trace import analyze_trace
 
-__all__ = ["analyze_trace"]
+__all__ = ["analyze_trace", "next_best_analyses"]

--- a/src/agenticlens/analysis/next_steps.py
+++ b/src/agenticlens/analysis/next_steps.py
@@ -1,0 +1,29 @@
+from agenticlens.models.trace import Finding
+
+
+def next_best_analyses(findings: list[Finding]) -> list[str]:
+    categories = {finding.category for finding in findings}
+    suggestions: list[str] = []
+    if not findings:
+        return suggestions
+    if "retry" in categories:
+        suggestions.append(
+            "Inspect retry parent spans and failure types to separate transient "
+            "tool errors from prompt issues."
+        )
+    if "memory" in categories:
+        suggestions.append(
+            "Review memory-read and memory-write spans to trim context that is "
+            "high-cost but low-signal."
+        )
+    if "context" in categories:
+        suggestions.append(
+            "Compare duplicated context groups to consolidate repeated retrieval "
+            "or prompt assembly work."
+        )
+    if not suggestions:
+        suggestions.append(
+            "Re-run the workflow with repeated samples and compare baseline "
+            "versus candidate traces."
+        )
+    return suggestions

--- a/src/agenticlens/analysis/trace.py
+++ b/src/agenticlens/analysis/trace.py
@@ -1,4 +1,25 @@
-from agenticlens.models.trace import Finding, Run, SpanType
+import json
+from collections import defaultdict
+from typing import Any
+
+from agenticlens.models.trace import Evidence, Finding, Run, Span, SpanType
+
+
+def _evidence(
+    *,
+    source: str,
+    span: Span | None = None,
+    reasoning: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> Evidence:
+    return Evidence(
+        source=source,
+        span_id=span.span_id if span else None,
+        timestamp=span.completed_at if span else None,
+        confidence=1.0,
+        reasoning=reasoning,
+        details=details or {},
+    )
 
 
 def memory_tokens(run: Run) -> int:
@@ -35,16 +56,77 @@ def retry_latency_share(run: Run) -> float:
     return retry_latency_ms(run) / run.total_latency_ms if run.total_latency_ms else 0.0
 
 
+def retry_attribution(run: Run) -> dict[str, dict[str, str | None]]:
+    attribution: dict[str, dict[str, str | None]] = {}
+    spans_by_id = {span.span_id: span for span in run.spans}
+    for retry_span in (span for span in run.spans if span.span_type is SpanType.RETRY):
+        triggering = spans_by_id.get(retry_span.parent_span_id or "")
+        if triggering is None:
+            retry_index = run.spans.index(retry_span)
+            triggering = next(
+                (
+                    candidate
+                    for candidate in reversed(run.spans[:retry_index])
+                    if candidate.status.value == "failed"
+                ),
+                None,
+            )
+        attribution[retry_span.span_id] = {
+            "triggering_failure_span_id": triggering.span_id if triggering else None,
+            "triggering_failure_type": triggering.error_type if triggering else None,
+        }
+    return attribution
+
+
+def classify_retry_outcomes(run: Run) -> dict[str, int]:
+    outcomes = {"recovered": 0, "failed": 0, "unknown": 0}
+    children_by_parent: dict[str, list[Span]] = defaultdict(list)
+    for span in run.spans:
+        if span.parent_span_id:
+            children_by_parent[span.parent_span_id].append(span)
+
+    for retry_span in (span for span in run.spans if span.span_type is SpanType.RETRY):
+        descendants = children_by_parent.get(retry_span.span_id, [])
+        if any(child.status.value == "succeeded" for child in descendants):
+            outcomes["recovered"] += 1
+        elif retry_span.status.value == "failed" or any(
+            child.status.value == "failed" for child in descendants
+        ):
+            outcomes["failed"] += 1
+        else:
+            outcomes["unknown"] += 1
+    return outcomes
+
+
+def duplicated_context_groups(run: Run) -> list[list[str]]:
+    groups: dict[str, list[str]] = defaultdict(list)
+    for span in run.spans:
+        fingerprint: str | None = None
+        if span.input_reference:
+            fingerprint = f"ref:{span.input_reference}"
+        elif span.input_data is not None:
+            fingerprint = "data:" + json.dumps(
+                span.input_data,
+                sort_keys=True,
+                ensure_ascii=True,
+                default=str,
+            )
+        if fingerprint:
+            groups[fingerprint].append(span.span_id)
+    return [span_ids for span_ids in groups.values() if len(span_ids) > 1]
+
+
 def analyze_trace(
     run: Run,
     *,
     memory_share_threshold: float = 0.5,
     retry_share_threshold: float = 0.2,
+    duplicated_context_threshold: int = 2,
 ) -> list[Finding]:
     """Produce deterministic findings whose evidence is reproducible from the trace."""
     findings: list[Finding] = []
     memory_spans = [
-        span.span_id
+        span
         for span in run.spans
         if span.span_type in {SpanType.MEMORY_READ, SpanType.MEMORY_WRITE}
     ]
@@ -57,18 +139,34 @@ def analyze_trace(
                 description="Memory spans consume a large share of recorded tokens.",
                 severity="medium",
                 confidence=1.0,
-                span_ids=memory_spans,
-                evidence={
-                    "memory_tokens": memory_tokens(run),
-                    "total_tokens": run.total_tokens,
-                    "memory_share": measured_memory_share,
-                    "threshold": memory_share_threshold,
-                },
+                span_ids=[span.span_id for span in memory_spans],
+                evidence=[
+                    _evidence(
+                        source="trace.metrics",
+                        reasoning="Memory spans exceed the configured token-share threshold.",
+                        details={
+                            "memory_tokens": memory_tokens(run),
+                            "total_tokens": run.total_tokens,
+                            "memory_share": measured_memory_share,
+                            "threshold": memory_share_threshold,
+                        },
+                    )
+                ]
+                + [
+                    _evidence(
+                        source="trace.span",
+                        span=span,
+                        details={"span_type": span.span_type.value, "tokens": span.total_tokens},
+                    )
+                    for span in memory_spans
+                ],
             )
         )
 
-    retry_spans = [span.span_id for span in run.spans if span.span_type is SpanType.RETRY]
+    retry_spans = [span for span in run.spans if span.span_type is SpanType.RETRY]
     measured_retry_share = retry_token_share(run)
+    retry_outcomes = classify_retry_outcomes(run)
+    retry_sources = retry_attribution(run)
     if measured_retry_share > retry_share_threshold:
         findings.append(
             Finding(
@@ -77,14 +175,55 @@ def analyze_trace(
                 description="Retry spans consume a large share of recorded tokens.",
                 severity="medium",
                 confidence=1.0,
-                span_ids=retry_spans,
-                evidence={
-                    "retry_tokens": retry_tokens(run),
-                    "retry_latency_ms": retry_latency_ms(run),
-                    "retry_cost_usd": retry_cost_usd(run),
-                    "retry_token_share": measured_retry_share,
-                    "threshold": retry_share_threshold,
-                },
+                span_ids=[span.span_id for span in retry_spans],
+                evidence=[
+                    _evidence(
+                        source="trace.metrics",
+                        reasoning="Retry spans exceed the configured token-share threshold.",
+                        details={
+                            "retry_tokens": retry_tokens(run),
+                            "retry_latency_ms": retry_latency_ms(run),
+                            "retry_cost_usd": retry_cost_usd(run),
+                            "retry_token_share": measured_retry_share,
+                            "threshold": retry_share_threshold,
+                            "outcomes": retry_outcomes,
+                        },
+                    )
+                ]
+                + [
+                    _evidence(
+                        source="trace.retry",
+                        span=span,
+                        details={
+                            "retry_number": span.retry_number,
+                            **retry_sources.get(span.span_id, {}),
+                        },
+                    )
+                    for span in retry_spans
+                ],
+            )
+        )
+
+    duplicate_groups = duplicated_context_groups(run)
+    if any(len(group) >= duplicated_context_threshold for group in duplicate_groups):
+        findings.append(
+            Finding(
+                category="context",
+                title="Duplicated context across spans",
+                description="The same context payload or reference is reused across spans.",
+                severity="low",
+                confidence=1.0,
+                span_ids=[span_id for group in duplicate_groups for span_id in group],
+                evidence=[
+                    _evidence(
+                        source="trace.context",
+                        reasoning=(
+                            "Duplicate context was detected from repeated input "
+                            "payloads or references."
+                        ),
+                        details={"duplicate_groups": duplicate_groups},
+                    )
+                ],
             )
         )
     return findings

--- a/src/agenticlens/cli/main.py
+++ b/src/agenticlens/cli/main.py
@@ -16,15 +16,19 @@ from agenticlens.comparison import (
     compare_runs,
     export_comparison_csv,
     export_comparison_json,
+    export_comparison_markdown,
     load_runs,
 )
 from agenticlens.evaluation import (
     EvaluationReport,
     GateConfig,
+    HTTPTarget,
+    PythonTarget,
     evaluate_gate,
     evaluate_suite,
     load_samples,
     load_suite,
+    run_live_suite,
     save_html_report,
 )
 from agenticlens.exporters import CSVExporter, JSONExporter
@@ -32,7 +36,7 @@ from agenticlens.models.trace import Run
 from agenticlens.models.workflow import Workflow
 from agenticlens.profiler.context import completed_workflows
 from agenticlens.recommenders import RecommendationEngine
-from agenticlens.reports import render_trace
+from agenticlens.reports import render_trace, render_trace_markdown
 
 app = typer.Typer(
     name="agenticlens",
@@ -134,9 +138,14 @@ def analyze(
 @app.command("inspect")
 def inspect_run(
     run_file: Path = typer.Argument(..., help="Path to a saved AgenticLens trace (JSON)."),
+    save: Path | None = typer.Option(None, "--save", help="Save a Markdown trace report."),
 ) -> None:
     """Inspect a validated run trace, span tree, and raw metric distributions."""
-    render_trace(console, _load_run(run_file))
+    run = _load_run(run_file)
+    render_trace(console, run)
+    if save is not None:
+        save.write_text(render_trace_markdown(run), encoding="utf-8")
+        console.print(f"Saved trace report to {save}")
 
 
 @app.command()
@@ -150,11 +159,20 @@ def compare(
         help="Relative degradation that counts as a regression.",
     ),
     save: Path | None = typer.Option(None, "--save", help="Save the comparison report."),
-    export_format: str = typer.Option("json", "--format", help="'json' or 'csv'."),
+    export_format: str = typer.Option("json", "--format", help="'json', 'csv', or 'md'."),
     fail_on_regression: bool = typer.Option(
         False,
         "--fail-on-regression",
         help="Return a non-zero exit status when regressions are detected.",
+    ),
+    min_samples: int | None = typer.Option(
+        None,
+        "--min-samples",
+        min=1,
+        help=(
+            "Require at least this many runs in both baseline and candidate cohorts. "
+            "Returns a non-zero exit status when the comparison is under-sampled."
+        ),
     ),
 ) -> None:
     """Compare repeated baseline and candidate traces."""
@@ -202,10 +220,22 @@ def compare(
             export_comparison_json(report, save)
         elif export_format == "csv":
             export_comparison_csv(report, save)
+        elif export_format == "md":
+            export_comparison_markdown(report, save)
         else:
             console.print(f"[red]Unknown export format:[/red] {export_format}")
             raise typer.Exit(code=1)
         console.print(f"Saved comparison to {save}")
+    if report.sample_size_guidance:
+        console.print(f"[yellow]{report.sample_size_guidance}[/yellow]")
+    if min_samples is not None:
+        observed_min = min(report.baseline.run_count, report.candidate.run_count)
+        if observed_min < min_samples:
+            console.print(
+                "[red]Comparison sample size requirement not met.[/red] "
+                f"Observed {observed_min} run(s); required at least {min_samples} per cohort."
+            )
+            raise typer.Exit(code=3)
     if fail_on_regression and report.regressions:
         raise typer.Exit(code=2)
 
@@ -253,6 +283,46 @@ def evaluate(
     console.print(f"Saved evaluation to {save}")
     if html is not None:
         console.print(f"Saved HTML report to {html}")
+
+
+@app.command("evaluate-live")
+def evaluate_live(
+    suite_file: Path = typer.Argument(..., help="YAML or JSON evaluation suite."),
+    target_kind: str = typer.Option(..., "--target-kind", help="'python' or 'http'."),
+    target: str = typer.Option(
+        ...,
+        "--target",
+        help="Python target as module:function or HTTP target as a URL.",
+    ),
+    save: Path = typer.Option(
+        Path("agenticlens-evaluation-live.json"),
+        "--save",
+        help="Save the machine-readable evaluation report.",
+    ),
+) -> None:
+    """Run one trusted live Python or HTTP target against an evaluation suite."""
+    try:
+        suite = load_suite(suite_file)
+        live_target = (
+            PythonTarget(callable_path=target)
+            if target_kind == "python"
+            else HTTPTarget(url=target)
+            if target_kind == "http"
+            else None
+        )
+        if live_target is None:
+            raise ValueError("target kind must be 'python' or 'http'")
+        result = run_live_suite(suite, live_target)
+    except (OSError, ValueError) as exc:
+        console.print(f"[red]Unable to run live evaluation:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    save.parent.mkdir(parents=True, exist_ok=True)
+    save.write_text(result.model_dump_json(indent=2), encoding="utf-8")
+    console.print(
+        "Live evaluation complete: "
+        f"{result.summary.passed_cases}/{result.summary.total_cases} cases passed."
+    )
+    console.print(f"Saved evaluation to {save}")
 
 
 @app.command()

--- a/src/agenticlens/comparison/__init__.py
+++ b/src/agenticlens/comparison/__init__.py
@@ -1,4 +1,9 @@
-from agenticlens.comparison.export import export_comparison_csv, export_comparison_json
+from agenticlens.comparison.export import (
+    export_comparison_csv,
+    export_comparison_json,
+    export_comparison_markdown,
+)
+from agenticlens.comparison.markdown import render_comparison_markdown
 from agenticlens.comparison.models import ComparisonReport, RunGroupSummary
 from agenticlens.comparison.runner import compare_runs, load_runs
 
@@ -8,5 +13,7 @@ __all__ = [
     "compare_runs",
     "export_comparison_csv",
     "export_comparison_json",
+    "export_comparison_markdown",
     "load_runs",
+    "render_comparison_markdown",
 ]

--- a/src/agenticlens/comparison/export.py
+++ b/src/agenticlens/comparison/export.py
@@ -1,6 +1,7 @@
 import csv
 from pathlib import Path
 
+from agenticlens.comparison.markdown import render_comparison_markdown
 from agenticlens.comparison.models import ComparisonReport
 
 
@@ -43,3 +44,7 @@ def export_comparison_csv(report: ComparisonReport, path: Path) -> None:
             )
         for name, baseline, candidate, delta in rows:
             writer.writerow([name, baseline, candidate, delta.absolute, delta.relative])
+
+
+def export_comparison_markdown(report: ComparisonReport, path: Path) -> None:
+    path.write_text(render_comparison_markdown(report), encoding="utf-8")

--- a/src/agenticlens/comparison/markdown.py
+++ b/src/agenticlens/comparison/markdown.py
@@ -1,0 +1,41 @@
+from agenticlens.comparison.models import ComparisonReport
+
+
+def render_comparison_markdown(report: ComparisonReport) -> str:
+    lines = [
+        "# Run Comparison",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Baseline | Candidate | Delta |",
+        "| --- | ---: | ---: | ---: |",
+        (
+            f"| Success rate | {report.baseline.success_rate:.1%} "
+            f"| {report.candidate.success_rate:.1%} "
+            f"| {report.success_rate_delta.absolute:+.1%} |"
+        ),
+        (
+            f"| Mean tokens | {report.baseline.tokens.mean:.1f} "
+            f"| {report.candidate.tokens.mean:.1f} "
+            f"| {report.mean_tokens_delta.absolute:+.1f} |"
+        ),
+        (
+            f"| Mean latency (ms) | {report.baseline.latency_ms.mean:.1f} "
+            f"| {report.candidate.latency_ms.mean:.1f} "
+            f"| {report.mean_latency_ms_delta.absolute:+.1f} |"
+        ),
+    ]
+    if report.mean_cost_usd_delta and report.baseline.cost_usd and report.candidate.cost_usd:
+        lines.append(
+            f"| Mean cost (USD) | {report.baseline.cost_usd.mean:.6f} "
+            f"| {report.candidate.cost_usd.mean:.6f} "
+            f"| {report.mean_cost_usd_delta.absolute:+.6f} |"
+        )
+    lines.extend(["", "## Regressions", ""])
+    if report.regressions:
+        lines.extend([f"- `{metric}`" for metric in report.regressions])
+    else:
+        lines.append("- None detected")
+    if report.sample_size_guidance:
+        lines.extend(["", "## Sample Size Guidance", "", report.sample_size_guidance])
+    return "\n".join(lines) + "\n"

--- a/src/agenticlens/comparison/models.py
+++ b/src/agenticlens/comparison/models.py
@@ -36,3 +36,5 @@ class ComparisonReport(BaseModel):
     mean_cost_usd_delta: MetricDelta | None = None
     regression_threshold: float
     regressions: list[str] = Field(default_factory=list)
+    minimum_sample_size: int = 5
+    sample_size_guidance: str | None = None

--- a/src/agenticlens/comparison/runner.py
+++ b/src/agenticlens/comparison/runner.py
@@ -121,6 +121,14 @@ def compare_runs(
         "mean_latency_ms": latency_delta,
         "mean_cost_usd": cost_delta,
     }
+    observed_min = min(len(baseline_runs), len(candidate_runs))
+    minimum_sample_size = 5
+    guidance = None
+    if observed_min < minimum_sample_size:
+        guidance = (
+            f"Only {observed_min} run(s) were provided for the smaller cohort; "
+            f"collect at least {minimum_sample_size} runs per cohort for more stable comparisons."
+        )
     return ComparisonReport(
         baseline=baseline,
         candidate=candidate,
@@ -130,4 +138,6 @@ def compare_runs(
         mean_cost_usd_delta=cost_delta,
         regression_threshold=regression_threshold,
         regressions=[name for name, delta in deltas.items() if delta and delta.regressed],
+        minimum_sample_size=minimum_sample_size,
+        sample_size_guidance=guidance,
     )

--- a/src/agenticlens/evaluation/__init__.py
+++ b/src/agenticlens/evaluation/__init__.py
@@ -1,4 +1,5 @@
 from agenticlens.evaluation.evaluators import (
+    BusinessRuleEvaluator,
     CallableEvaluator,
     EvaluationContext,
     Evaluator,
@@ -11,13 +12,17 @@ from agenticlens.evaluation.models import (
     EvaluationReport,
     EvaluationSample,
     EvaluatorConfig,
+    HTTPTarget,
+    LiveTarget,
+    PythonTarget,
     Score,
     TestCase,
     TestSuite,
 )
-from agenticlens.evaluation.runner import evaluate_suite, load_samples, load_suite
+from agenticlens.evaluation.runner import evaluate_suite, load_samples, load_suite, run_live_suite
 
 __all__ = [
+    "BusinessRuleEvaluator",
     "CallableEvaluator",
     "EvaluationContext",
     "EvaluationReport",
@@ -27,7 +32,10 @@ __all__ = [
     "EvaluatorRegistry",
     "GateConfig",
     "GateDecision",
+    "HTTPTarget",
     "LLMJudgeEvaluator",
+    "LiveTarget",
+    "PythonTarget",
     "Score",
     "TestCase",
     "TestSuite",
@@ -36,5 +44,6 @@ __all__ = [
     "load_samples",
     "load_suite",
     "render_html_report",
+    "run_live_suite",
     "save_html_report",
 ]

--- a/src/agenticlens/evaluation/evaluators.py
+++ b/src/agenticlens/evaluation/evaluators.py
@@ -69,6 +69,13 @@ class LLMJudgeEvaluator(CallableEvaluator):
         super().__init__(name, judge, evaluator_type="llm_judge")
 
 
+class BusinessRuleEvaluator(CallableEvaluator):
+    """Named helper for application-specific pass/fail logic."""
+
+    def __init__(self, name: str, rule: EvaluationFunction) -> None:
+        super().__init__(name, rule, evaluator_type="business_rule")
+
+
 class EvaluatorRegistry:
     def __init__(self) -> None:
         self._evaluators: dict[str, Evaluator] = {}

--- a/src/agenticlens/evaluation/models.py
+++ b/src/agenticlens/evaluation/models.py
@@ -19,10 +19,14 @@ class TestCase(BaseModel):
     input: Any = None
     expected_output: str | None = None
     expected_contains: list[str] = Field(default_factory=list)
+    output_json_schema: dict[str, Any] | None = None
+    required_output_fields: list[str] = Field(default_factory=list)
     required_tools: list[str] = Field(default_factory=list)
     forbidden_tools: list[str] = Field(default_factory=list)
+    required_tool_arguments: dict[str, list[str]] = Field(default_factory=dict)
     max_latency_ms: float | None = Field(default=None, gt=0)
     max_cost_usd: float | None = Field(default=None, ge=0)
+    max_turns: int | None = Field(default=None, gt=0)
     evaluators: list[EvaluatorConfig] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -33,10 +37,14 @@ class TestCase(BaseModel):
             (
                 self.expected_output is not None,
                 self.expected_contains,
+                self.output_json_schema is not None,
+                self.required_output_fields,
                 self.required_tools,
                 self.forbidden_tools,
+                self.required_tool_arguments,
                 self.max_latency_ms is not None,
                 self.max_cost_usd is not None,
+                self.max_turns is not None,
                 self.evaluators,
             )
         ):
@@ -105,3 +113,20 @@ class EvaluationReport(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     summary: EvaluationSummary
     cases: list[CaseEvaluation]
+
+
+class LiveTarget(BaseModel):
+    kind: str = Field(pattern="^(python|http)$")
+    timeout_seconds: float = Field(default=30.0, gt=0)
+
+
+class PythonTarget(LiveTarget):
+    kind: str = "python"
+    callable_path: str
+
+
+class HTTPTarget(LiveTarget):
+    kind: str = "http"
+    url: str
+    method: str = "POST"
+    headers: dict[str, str] = Field(default_factory=dict)

--- a/src/agenticlens/evaluation/runner.py
+++ b/src/agenticlens/evaluation/runner.py
@@ -1,4 +1,8 @@
 import json
+import urllib.error
+import urllib.request
+from importlib import import_module
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +14,9 @@ from agenticlens.evaluation.models import (
     EvaluationReport,
     EvaluationSample,
     EvaluationSummary,
+    HTTPTarget,
+    LiveTarget,
+    PythonTarget,
     Score,
     TestCase,
     TestSuite,
@@ -29,6 +36,59 @@ def load_samples(path: Path) -> list[EvaluationSample]:
     data = _load_data(path)
     items = data["samples"] if isinstance(data, dict) and "samples" in data else data
     return [EvaluationSample.model_validate(item) for item in items]
+
+
+def _lookup_path(payload: Any, dotted_path: str) -> tuple[bool, Any]:
+    current = payload
+    for part in dotted_path.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        elif isinstance(current, list) and part.isdigit() and int(part) < len(current):
+            current = current[int(part)]
+        else:
+            return False, None
+    return True, current
+
+
+def _validate_json_schema(payload: Any, schema: dict[str, Any]) -> tuple[bool, str]:
+    expected_type = schema.get("type")
+    type_map: dict[str, type[Any] | tuple[type[Any], ...]] = {
+        "object": dict,
+        "array": list,
+        "string": str,
+        "number": (int, float),
+        "integer": int,
+        "boolean": bool,
+    }
+    expected_python_type = type_map.get(expected_type) if expected_type else None
+    if expected_type and expected_python_type is None:
+        return False, f"Unsupported JSON schema type {expected_type!r}."
+    if expected_python_type is not None and not isinstance(payload, expected_python_type):
+        return False, f"Expected JSON type {expected_type!r}."
+    if isinstance(payload, dict):
+        required = schema.get("required", [])
+        missing = [name for name in required if name not in payload]
+        if missing:
+            return False, f"Missing required JSON fields: {', '.join(missing)}."
+        properties = schema.get("properties", {})
+        for key, subschema in properties.items():
+            if key in payload:
+                valid, reason = _validate_json_schema(payload[key], subschema)
+                if not valid:
+                    return False, f"Field {key!r}: {reason}"
+    if isinstance(payload, list) and "items" in schema:
+        for item in payload:
+            valid, reason = _validate_json_schema(item, schema["items"])
+            if not valid:
+                return False, reason
+    return True, "Output matches the configured JSON schema subset."
+
+
+def _turn_count(sample: EvaluationSample) -> int:
+    metadata_turns = sample.trace.metadata.get("turn_count")
+    if isinstance(metadata_turns, int) and metadata_turns > 0:
+        return metadata_turns
+    return len(sample.trace.spans)
 
 
 def _score_case(
@@ -62,6 +122,54 @@ def _score_case(
                 else f"Output is missing required text: {expected!r}.",
             )
         )
+    parsed_output: Any | None = None
+    output_json_error: str | None = None
+    if case.output_json_schema is not None or case.required_output_fields:
+        try:
+            parsed_output = json.loads(output)
+        except json.JSONDecodeError as exc:
+            output_json_error = str(exc)
+    if case.output_json_schema is not None:
+        if output_json_error is not None:
+            scores.append(
+                Score(
+                    name="json_schema",
+                    value=0.0,
+                    passed=False,
+                    explanation=f"Output is not valid JSON: {output_json_error}.",
+                )
+            )
+        else:
+            valid, reason = _validate_json_schema(parsed_output, case.output_json_schema)
+            scores.append(
+                Score(
+                    name="json_schema",
+                    value=float(valid),
+                    passed=valid,
+                    explanation=reason,
+                )
+            )
+    for field_path in case.required_output_fields:
+        exists = (
+            output_json_error is None
+            and parsed_output is not None
+            and _lookup_path(parsed_output, field_path)[0]
+        )
+        scores.append(
+            Score(
+                name=f"required_field:{field_path}",
+                value=float(exists),
+                passed=exists,
+                explanation=f"Output contains required field {field_path!r}."
+                if exists
+                else (
+                    "Output is not valid JSON, so required field "
+                    f"{field_path!r} could not be checked."
+                    if output_json_error is not None
+                    else f"Output is missing required field {field_path!r}."
+                ),
+            )
+        )
 
     tools = {span.tool_name for span in sample.trace.spans if span.tool_name}
     for tool in case.required_tools:
@@ -86,6 +194,24 @@ def _score_case(
                 explanation=f"Forbidden tool {tool!r} was not called."
                 if passed
                 else f"Forbidden tool {tool!r} was called.",
+            )
+        )
+    for tool_name, required_args in case.required_tool_arguments.items():
+        matching_spans = [span for span in sample.trace.spans if span.tool_name == tool_name]
+        args_present = False
+        for span in matching_spans:
+            tool_args = span.attributes.get("tool_args")
+            if isinstance(tool_args, dict) and all(arg in tool_args for arg in required_args):
+                args_present = True
+                break
+        scores.append(
+            Score(
+                name=f"tool_args:{tool_name}",
+                value=float(args_present),
+                passed=args_present,
+                explanation=f"Tool {tool_name!r} included required arguments {required_args}."
+                if args_present
+                else f"Tool {tool_name!r} did not include required arguments {required_args}.",
             )
         )
     if case.max_latency_ms is not None:
@@ -117,6 +243,20 @@ def _score_case(
                 ),
             )
         )
+    if case.max_turns is not None:
+        turns = _turn_count(sample)
+        passed = turns <= case.max_turns
+        scores.append(
+            Score(
+                name="turn_count_threshold",
+                value=float(passed),
+                passed=passed,
+                explanation=(
+                    f"Turn count {turns} {'meets' if passed else 'exceeds'} the "
+                    f"{case.max_turns} turn limit."
+                ),
+            )
+        )
     for evaluator_config in case.evaluators:
         if registry is None:
             raise ValueError(
@@ -129,6 +269,67 @@ def _score_case(
         )
         scores.extend(custom_scores)
     return scores
+
+
+def _load_python_callable(callable_path: str) -> Any:
+    """Load a trusted Python live target from module:function or path.py:function."""
+    module_name, _, attr_path = callable_path.partition(":")
+    if not module_name or not attr_path:
+        raise ValueError("python target callable_path must be in module:function format")
+    try:
+        target: Any = import_module(module_name)
+    except ModuleNotFoundError as exc:
+        file_path = Path(module_name)
+        if not file_path.exists():
+            raise
+        spec = spec_from_file_location(file_path.stem, file_path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Unable to load Python target from {file_path}") from exc
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+        target = module
+    for part in attr_path.split("."):
+        target = getattr(target, part)
+    return target
+
+
+def run_live_suite(
+    suite: TestSuite,
+    target: LiveTarget,
+    *,
+    registry: EvaluatorRegistry | None = None,
+) -> EvaluationReport:
+    """Run a trusted live target against every case in a suite.
+
+    Live targets are intentionally powerful developer-facing integrations:
+    Python targets execute local code and HTTP targets can reach arbitrary URLs.
+    Only use trusted suite files and trusted target definitions.
+    """
+    samples: list[EvaluationSample] = []
+    if isinstance(target, PythonTarget):
+        callable_target = _load_python_callable(target.callable_path)
+        for case in suite.cases:
+            result = callable_target(case.input, case=case)
+            sample = EvaluationSample.model_validate({**result, "case_id": case.id})
+            samples.append(sample)
+    elif isinstance(target, HTTPTarget):
+        for case in suite.cases:
+            request = urllib.request.Request(
+                target.url,
+                data=json.dumps({"input": case.input, "case_id": case.id}).encode("utf-8"),
+                headers={"Content-Type": "application/json", **target.headers},
+                method=target.method.upper(),
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=target.timeout_seconds) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+            except urllib.error.URLError as exc:
+                raise ValueError(f"HTTP target request failed for case {case.id!r}: {exc}") from exc
+            sample = EvaluationSample.model_validate({**payload, "case_id": case.id})
+            samples.append(sample)
+    else:
+        raise ValueError(f"Unsupported live target kind: {target.kind}")
+    return evaluate_suite(suite, samples, registry=registry)
 
 
 def evaluate_suite(

--- a/src/agenticlens/models/__init__.py
+++ b/src/agenticlens/models/__init__.py
@@ -2,7 +2,7 @@ from agenticlens.models.enums import Severity, StepType
 from agenticlens.models.metrics import Metrics
 from agenticlens.models.recommendation import Recommendation
 from agenticlens.models.step import Step
-from agenticlens.models.trace import Finding, MetricValue, Run, RunStatus, Span, SpanType
+from agenticlens.models.trace import Evidence, Finding, MetricValue, Run, RunStatus, Span, SpanType
 from agenticlens.models.workflow import Workflow
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
     "Severity",
     "Step",
     "StepType",
+    "Evidence",
     "Finding",
     "MetricValue",
     "Run",

--- a/src/agenticlens/models/recommendation.py
+++ b/src/agenticlens/models/recommendation.py
@@ -3,6 +3,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from agenticlens.models.enums import Severity
+from agenticlens.models.trace import Evidence
 
 
 class Recommendation(BaseModel):
@@ -24,6 +25,7 @@ class Recommendation(BaseModel):
     estimated_monthly_savings: float | None = None
     confidence: float | None = None
     quality_risk: str | None = None
+    evidence: list[Evidence] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
     cost_savings: float | None = Field(
         default=None,

--- a/src/agenticlens/models/trace.py
+++ b/src/agenticlens/models/trace.py
@@ -91,6 +91,7 @@ class Run(BaseModel):
         if len(ids) != len(set(ids)):
             raise ValueError("span_id values must be unique within a run")
         known = set(ids)
+        parents = {span.span_id: span.parent_span_id for span in self.spans}
         for span in self.spans:
             if span.parent_span_id is not None and span.parent_span_id not in known:
                 raise ValueError(
@@ -98,6 +99,14 @@ class Run(BaseModel):
                 )
             if span.parent_span_id == span.span_id:
                 raise ValueError(f"span {span.span_id} cannot be its own parent")
+        for span_id in ids:
+            seen: set[str] = set()
+            current: str | None = span_id
+            while current is not None:
+                if current in seen:
+                    raise ValueError(f"span tree contains a cycle involving {current}")
+                seen.add(current)
+                current = parents.get(current)
         return self
 
     @property
@@ -134,6 +143,15 @@ class MetricValue(BaseModel):
     attributes: dict[str, Any] = Field(default_factory=dict)
 
 
+class Evidence(BaseModel):
+    source: str
+    span_id: str | None = None
+    timestamp: datetime | None = None
+    confidence: float = Field(default=1.0, ge=0, le=1)
+    reasoning: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
 class Finding(BaseModel):
     finding_id: str = Field(default_factory=_uuid)
     category: str
@@ -142,4 +160,4 @@ class Finding(BaseModel):
     severity: str
     confidence: float = Field(ge=0, le=1)
     span_ids: list[str] = Field(default_factory=list)
-    evidence: dict[str, Any] = Field(default_factory=dict)
+    evidence: list[Evidence] = Field(default_factory=list)

--- a/src/agenticlens/recommenders/engine.py
+++ b/src/agenticlens/recommenders/engine.py
@@ -1,6 +1,7 @@
 from agenticlens.config.settings import RecommenderConfig
 from agenticlens.models.enums import Severity
 from agenticlens.models.recommendation import Recommendation
+from agenticlens.models.trace import Evidence
 from agenticlens.models.workflow import Workflow
 from agenticlens.recommenders.base import BaseRecommender
 from agenticlens.recommenders.chaos_impact import ChaosImpactRecommender
@@ -63,6 +64,8 @@ class RecommendationEngine:
             total_cost / total_tokens if total_cost is not None and total_tokens > 0 else None
         )
 
+        steps_by_id = {step.id: step for step in workflow.steps}
+        steps_by_name = {step.name: step for step in workflow.steps}
         enriched: list[Recommendation] = []
         for rec in recommendations:
             savings_pct = (
@@ -83,6 +86,24 @@ class RecommendationEngine:
             # graded by budget impact -- keep the severity they assigned themselves.
             if rec.tokens_saved > 0:
                 rec.severity = self._severity_for(savings_pct, usd_savings)
+            if not rec.evidence:
+                step = None
+                if rec.step_id:
+                    step = steps_by_id.get(rec.step_id)
+                elif rec.step_name:
+                    step = steps_by_name.get(rec.step_name)
+                rec.evidence = [
+                    Evidence(
+                        source="workflow.step" if step else "workflow.recommendation",
+                        span_id=step.id if step else rec.step_id,
+                        reasoning="Recommendation derived from profiled workflow evidence.",
+                        details={
+                            "step_name": step.name if step else rec.step_name,
+                            "step_type": step.type.value if step else rec.step_type,
+                            "optimization_type": rec.optimization_type,
+                        },
+                    )
+                ]
             enriched.append(rec)
 
         return sorted(

--- a/src/agenticlens/reports/__init__.py
+++ b/src/agenticlens/reports/__init__.py
@@ -1,3 +1,3 @@
-from agenticlens.reports.trace import render_trace
+from agenticlens.reports.trace import render_trace, render_trace_markdown
 
-__all__ = ["render_trace"]
+__all__ = ["render_trace", "render_trace_markdown"]

--- a/src/agenticlens/reports/trace.py
+++ b/src/agenticlens/reports/trace.py
@@ -2,7 +2,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.tree import Tree
 
-from agenticlens.analysis import analyze_trace
+from agenticlens.analysis import analyze_trace, next_best_analyses
 from agenticlens.metrics.trace import (
     latency_by_span_type,
     retry_count,
@@ -10,6 +10,10 @@ from agenticlens.metrics.trace import (
     tool_call_count,
 )
 from agenticlens.models.trace import Run, Span
+
+
+def _escape_markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\r", "").replace("\n", "<br>")
 
 
 def _span_label(span: Span) -> str:
@@ -67,6 +71,61 @@ def render_trace(console: Console, run: Run) -> None:
             finding_table.add_row(
                 finding.severity,
                 finding.title,
-                ", ".join(f"{key}={value}" for key, value in finding.evidence.items()),
+                "; ".join(
+                    f"{item.source}: {item.reasoning or item.details}" for item in finding.evidence
+                ),
             )
         console.print(finding_table)
+        suggestions = next_best_analyses(findings)
+        if suggestions:
+            console.print("[bold]Next Best Analysis[/bold]")
+            for suggestion in suggestions:
+                console.print(f"  • {suggestion}")
+
+
+def render_trace_markdown(run: Run) -> str:
+    findings = analyze_trace(run)
+    lines = [
+        f"# Trace Report: {run.application_name}",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| Run ID | `{run.run_id}` |",
+        f"| Status | {run.status.value} |",
+        f"| Total tokens | {run.total_tokens} |",
+        f"| Latency (ms) | {run.total_latency_ms:.1f} |",
+        f"| Retries | {retry_count(run)} |",
+        f"| Tool calls | {tool_call_count(run)} |",
+        "",
+        "## Spans",
+        "",
+        "| Name | Type | Parent | Tokens | Latency (ms) | Status |",
+        "| --- | --- | --- | ---: | ---: | --- |",
+    ]
+    for span in run.spans:
+        lines.append(
+            f"| {_escape_markdown_cell(span.name)} | {span.span_type.value} "
+            f"| {_escape_markdown_cell(span.parent_span_id or '-')} "
+            f"| {span.total_tokens} | {span.latency_ms:.1f} | {span.status.value} |"
+        )
+    if findings:
+        lines.extend(["", "## Findings", ""])
+        for finding in findings:
+            lines.append(f"### {finding.title}")
+            lines.append("")
+            lines.append(f"- Severity: {finding.severity}")
+            lines.append(f"- Category: {finding.category}")
+            lines.append(f"- Confidence: {finding.confidence:.2f}")
+            if finding.span_ids:
+                lines.append(f"- Spans: {', '.join(finding.span_ids)}")
+            for item in finding.evidence:
+                lines.append(f"- Evidence ({item.source}): {item.reasoning or item.details}")
+            lines.append("")
+        suggestions = next_best_analyses(findings)
+        if suggestions:
+            lines.extend(["## Next Best Analysis", ""])
+            lines.extend([f"- {suggestion}" for suggestion in suggestions])
+            lines.append("")
+    return "\n".join(lines) + "\n"

--- a/tests/live_eval_target.py
+++ b/tests/live_eval_target.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta, timezone
+
+
+def run_case(payload, *, case):
+    started = datetime.now(timezone.utc)
+    trace = {
+        "application_name": "live-target",
+        "started_at": started.isoformat(),
+        "completed_at": (started + timedelta(milliseconds=25)).isoformat(),
+        "status": "succeeded",
+        "task_success": True,
+        "metadata": {"turn_count": 1},
+        "spans": [
+            {
+                "name": "tool",
+                "span_type": "tool_call",
+                "status": "succeeded",
+                "tool_name": "add",
+                "attributes": {"tool_args": {"a": 40, "b": 2}},
+            }
+        ],
+    }
+    return {"output": payload["response"], "trace": trace}

--- a/tests/test_architecture_imports.py
+++ b/tests/test_architecture_imports.py
@@ -1,0 +1,32 @@
+import ast
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "agenticlens"
+FORBIDDEN_IMPORTS = {
+    "exporters": ("agenticlens.cli",),
+    "comparison": ("agenticlens.cli",),
+    "evaluation": ("agenticlens.cli",),
+}
+
+
+def _imports_in(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return imports
+
+
+def test_package_layers_do_not_import_cli() -> None:
+    for package, forbidden_prefixes in FORBIDDEN_IMPORTS.items():
+        package_root = SRC_ROOT / package
+        for file in package_root.rglob("*.py"):
+            imports = _imports_in(file)
+            assert not any(
+                imported == prefix or imported.startswith(f"{prefix}.")
+                for prefix in forbidden_prefixes
+                for imported in imports
+            ), f"{file} imports a forbidden module from {forbidden_prefixes!r}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,19 @@ def test_inspect_trace(tmp_path):
     assert "demo" in result.output
 
 
+def test_inspect_trace_can_save_markdown(tmp_path):
+    trace_file = tmp_path / "trace.json"
+    markdown_file = tmp_path / "trace.md"
+    trace_file.write_text(
+        '{"application_name":"demo","status":"succeeded","spans":[]}',
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(app, ["inspect", str(trace_file), "--save", str(markdown_file)])
+    assert result.exit_code == 0
+    assert markdown_file.exists()
+    assert "Trace Report" in markdown_file.read_text(encoding="utf-8")
+
+
 def test_compare_trace_directories(tmp_path):
     baseline = tmp_path / "baseline"
     candidate = tmp_path / "candidate"
@@ -38,6 +51,43 @@ def test_compare_trace_directories(tmp_path):
     assert result.exit_code == 0
     assert "No regressions detected" in result.output
     assert report_file.exists()
+
+
+def test_compare_can_save_markdown(tmp_path):
+    baseline = tmp_path / "baseline"
+    candidate = tmp_path / "candidate"
+    baseline.mkdir()
+    candidate.mkdir()
+    payload = '{"application_name":"demo","status":"succeeded","task_success":true,"spans":[]}'
+    (baseline / "run.json").write_text(payload, encoding="utf-8")
+    (candidate / "run.json").write_text(payload, encoding="utf-8")
+    report_file = tmp_path / "comparison.md"
+
+    result = CliRunner().invoke(
+        app,
+        ["compare", str(baseline), str(candidate), "--save", str(report_file), "--format", "md"],
+    )
+
+    assert result.exit_code == 0
+    assert "Sample Size Guidance" in report_file.read_text(encoding="utf-8")
+
+
+def test_compare_can_enforce_min_samples(tmp_path):
+    baseline = tmp_path / "baseline"
+    candidate = tmp_path / "candidate"
+    baseline.mkdir()
+    candidate.mkdir()
+    payload = '{"application_name":"demo","status":"succeeded","task_success":true,"spans":[]}'
+    (baseline / "run.json").write_text(payload, encoding="utf-8")
+    (candidate / "run.json").write_text(payload, encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        ["compare", str(baseline), str(candidate), "--min-samples", "2"],
+    )
+
+    assert result.exit_code == 3
+    assert "sample size requirement not met" in result.output.lower()
 
 
 runner = CliRunner()
@@ -171,3 +221,51 @@ def test_cli_analyze_no_recommendations(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert "no optimization suggestions" in result.output.lower()
+
+
+def test_evaluate_live_python_target(tmp_path: Path) -> None:
+    suite_file = tmp_path / "suite.json"
+    report_file = tmp_path / "evaluation.json"
+    suite_file.write_text(
+        json.dumps(
+            {
+                "name": "live",
+                "version": "1",
+                "cases": [
+                    {
+                        "id": "case-1",
+                        "name": "Live target",
+                        "input": {"response": '{"answer":"42","meta":{"confidence":0.9}}'},
+                        "output_json_schema": {"type": "object", "required": ["answer"]},
+                        "required_tool_arguments": {"add": ["a", "b"]},
+                        "max_turns": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "evaluate-live",
+            str(suite_file),
+            "--target-kind",
+            "python",
+            "--target",
+            "tests/live_eval_target.py:run_case",
+            "--save",
+            str(report_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert report_file.exists()
+    assert "Live evaluation complete" in result.output
+
+
+def test_evaluate_live_help_mentions_trusted_targets() -> None:
+    result = runner.invoke(app, ["evaluate-live", "--help"])
+    assert result.exit_code == 0
+    assert "trusted live python or http target" in result.output.lower()

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from agenticlens.comparison import compare_runs
+from agenticlens.comparison import compare_runs, render_comparison_markdown
 from agenticlens.comparison.runner import summarize_runs
 from agenticlens.models.trace import Run, RunStatus, Span, SpanType
 
@@ -67,3 +67,13 @@ def test_compare_detects_quality_and_efficiency_regressions():
 def test_comparison_requires_runs():
     with pytest.raises(ValueError, match="At least one run"):
         summarize_runs("empty", [])
+
+
+def test_comparison_adds_minimum_sample_guidance_and_markdown():
+    baseline = [_run(success=True, tokens=100, latency_ms=100)]
+    candidate = [_run(success=True, tokens=90, latency_ms=90)]
+    report = compare_runs(baseline, candidate)
+
+    assert report.sample_size_guidance is not None
+    markdown = render_comparison_markdown(report)
+    assert "Sample Size Guidance" in markdown

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -3,16 +3,19 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from agenticlens.evaluation import (
+    BusinessRuleEvaluator,
     EvaluationContext,
     EvaluationSample,
     EvaluatorConfig,
     EvaluatorRegistry,
     GateConfig,
     LLMJudgeEvaluator,
+    PythonTarget,
     Score,
     evaluate_gate,
     evaluate_suite,
     render_html_report,
+    run_live_suite,
 )
 from agenticlens.evaluation import (
     TestCase as EvaluationTestCase,
@@ -177,3 +180,161 @@ def test_unregistered_evaluator_is_rejected() -> None:
             suite,
             [EvaluationSample(case_id="case-1", output="ok", trace=make_run())],
         )
+
+
+def test_evaluate_suite_supports_json_fields_tool_args_and_turn_thresholds() -> None:
+    suite = EvaluationTestSuite(
+        name="structured",
+        version="1",
+        cases=[
+            EvaluationTestCase(
+                id="case-1",
+                name="Structured output",
+                output_json_schema={
+                    "type": "object",
+                    "required": ["answer", "meta"],
+                    "properties": {
+                        "answer": {"type": "string"},
+                        "meta": {"type": "object", "required": ["confidence"]},
+                    },
+                },
+                required_output_fields=["meta.confidence"],
+                required_tool_arguments={"add": ["a", "b"]},
+                max_turns=2,
+            )
+        ],
+    )
+    run = make_run()
+    run.metadata["turn_count"] = 2
+    run.spans[0].attributes["tool_args"] = {"a": 40, "b": 2}
+
+    report = evaluate_suite(
+        suite,
+        [
+            EvaluationSample(
+                case_id="case-1",
+                output='{"answer":"42","meta":{"confidence":0.9}}',
+                trace=run,
+            )
+        ],
+    )
+    assert report.cases[0].passed
+    assert {score.name for score in report.cases[0].scores} >= {
+        "json_schema",
+        "required_field:meta.confidence",
+        "tool_args:add",
+        "turn_count_threshold",
+    }
+
+
+def test_business_rule_evaluator_uses_business_rule_type() -> None:
+    registry = EvaluatorRegistry()
+    registry.register(
+        BusinessRuleEvaluator(
+            "business_rule",
+            lambda context: Score(
+                name="vip_rule",
+                value=1.0 if context.sample.output == "vip" else 0.0,
+                passed=False,
+                explanation="VIP response requirement.",
+            ),
+        )
+    )
+    suite = EvaluationTestSuite(
+        name="business",
+        version="1",
+        cases=[
+            EvaluationTestCase(
+                id="case-1",
+                name="VIP policy",
+                evaluators=[EvaluatorConfig(name="business_rule")],
+            )
+        ],
+    )
+    report = evaluate_suite(
+        suite,
+        [EvaluationSample(case_id="case-1", output="vip", trace=make_run())],
+        registry=registry,
+    )
+    assert report.cases[0].scores[0].evaluator_type == "business_rule"
+
+
+def test_run_live_suite_executes_python_target() -> None:
+    suite = EvaluationTestSuite(
+        name="live",
+        version="1",
+        cases=[
+            EvaluationTestCase(
+                id="case-1",
+                name="Answer",
+                input={"response": '{"answer":"42","meta":{"confidence":0.9}}'},
+                output_json_schema={"type": "object", "required": ["answer"]},
+                required_tool_arguments={"add": ["a", "b"]},
+                max_turns=1,
+            )
+        ],
+    )
+    report = run_live_suite(
+        suite,
+        PythonTarget(callable_path="tests/live_eval_target.py:run_case"),
+    )
+    assert report.summary.pass_rate == 1.0
+
+
+def test_run_live_suite_preserves_suite_case_id_when_target_returns_one(tmp_path) -> None:
+    target_file = tmp_path / "target.py"
+    target_file.write_text(
+        "\n".join(
+            [
+                "from datetime import datetime, timezone",
+                "",
+                "def run_case(payload, *, case):",
+                "    return {",
+                "        'case_id': 'wrong-case',",
+                "        'output': 'ok',",
+                "        'trace': {",
+                "            'application_name': 'live-target',",
+                "            'started_at': datetime.now(timezone.utc).isoformat(),",
+                "            'completed_at': datetime.now(timezone.utc).isoformat(),",
+                "            'status': 'succeeded',",
+                "            'task_success': True,",
+                "            'spans': [],",
+                "        },",
+                "    }",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    suite = EvaluationTestSuite(
+        name="live",
+        version="1",
+        cases=[EvaluationTestCase(id="case-1", name="Answer", expected_output="ok")],
+    )
+
+    report = run_live_suite(
+        suite,
+        PythonTarget(callable_path=f"{target_file}:run_case"),
+    )
+
+    assert report.cases[0].case_id == "case-1"
+
+
+def test_json_schema_reports_unsupported_type_gracefully() -> None:
+    suite = EvaluationTestSuite(
+        name="schema",
+        version="1",
+        cases=[
+            EvaluationTestCase(
+                id="case-1",
+                name="Unsupported type",
+                output_json_schema={"type": "null"},
+            )
+        ],
+    )
+    report = evaluate_suite(
+        suite,
+        [EvaluationSample(case_id="case-1", output="null", trace=make_run())],
+    )
+
+    assert not report.cases[0].passed
+    assert report.cases[0].scores[0].explanation == "Unsupported JSON schema type 'null'."

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -6,7 +6,10 @@ from pydantic import ValidationError
 from agenticlens import Run, RunStatus, SpanType, trace
 from agenticlens.analysis.trace import (
     analyze_trace,
+    classify_retry_outcomes,
+    duplicated_context_groups,
     memory_share,
+    retry_attribution,
     retry_latency_ms,
     retry_token_share,
 )
@@ -71,6 +74,18 @@ def test_run_rejects_unknown_parent():
         ],
     }
     with pytest.raises(ValidationError, match="unknown parent"):
+        Run.model_validate(payload)
+
+
+def test_run_rejects_parent_cycles():
+    payload = {
+        "application_name": "bad",
+        "spans": [
+            {"span_id": "a", "name": "one", "span_type": "custom", "parent_span_id": "b"},
+            {"span_id": "b", "name": "two", "span_type": "custom", "parent_span_id": "a"},
+        ],
+    }
+    with pytest.raises(ValidationError, match="cycle"):
         Run.model_validate(payload)
 
 
@@ -155,3 +170,35 @@ def test_memory_and_retry_analysis_cites_span_evidence():
     findings = analyze_trace(recording.run)
     assert {finding.category for finding in findings} == {"memory", "retry"}
     assert findings[0].span_ids
+    assert findings[0].evidence
+
+
+def test_retry_analysis_attributes_triggering_failure_and_outcomes():
+    recording = trace("retry-attribution")
+    with recording:
+        with pytest.raises(RuntimeError), recording.span("tool", SpanType.TOOL_CALL):
+            raise RuntimeError("network")
+        with recording.span("retry", SpanType.RETRY) as retry:
+            retry.record_tokens(5, 0)
+            with recording.span("tool-success", SpanType.TOOL_CALL):
+                pass
+
+    outcomes = classify_retry_outcomes(recording.run)
+    attribution = retry_attribution(recording.run)
+    retry_span = next(span for span in recording.run.spans if span.span_type is SpanType.RETRY)
+    assert outcomes["recovered"] == 1
+    assert attribution[retry_span.span_id]["triggering_failure_span_id"]
+    assert "triggering_failure_span_id" not in retry_span.attributes
+
+
+def test_duplicate_context_detection_groups_reused_inputs():
+    with trace("duplicates") as recording:
+        with recording.span("one", SpanType.MODEL_CALL, input_reference="context:42"):
+            pass
+        with recording.span("two", SpanType.MODEL_CALL, input_reference="context:42"):
+            pass
+
+    groups = duplicated_context_groups(recording.run)
+    findings = analyze_trace(recording.run, duplicated_context_threshold=2)
+    assert groups == [[recording.run.spans[0].span_id, recording.run.spans[1].span_id]]
+    assert any(finding.category == "context" for finding in findings)

--- a/tests/test_trace_reports.py
+++ b/tests/test_trace_reports.py
@@ -1,0 +1,98 @@
+from datetime import datetime, timedelta, timezone
+
+from rich.console import Console
+
+from agenticlens.analysis import next_best_analyses
+from agenticlens.models.trace import Finding, Run, RunStatus, Span, SpanType
+from agenticlens.reports import render_trace, render_trace_markdown
+
+
+def _run_with_findings() -> Run:
+    started = datetime.now(timezone.utc)
+    return Run(
+        application_name="trace-demo",
+        started_at=started,
+        completed_at=started + timedelta(milliseconds=250),
+        status=RunStatus.SUCCEEDED,
+        task_success=True,
+        spans=[
+            Span(
+                span_id="memory",
+                name="memory lookup",
+                span_type=SpanType.MEMORY_READ,
+                status=RunStatus.SUCCEEDED,
+                input_tokens=80,
+            ),
+            Span(
+                span_id="retry",
+                name="retry planner",
+                span_type=SpanType.RETRY,
+                status=RunStatus.SUCCEEDED,
+                input_tokens=30,
+            ),
+            Span(
+                span_id="retry-child",
+                parent_span_id="retry",
+                name="tool after retry",
+                span_type=SpanType.TOOL_CALL,
+                status=RunStatus.SUCCEEDED,
+                tool_name="lookup",
+                input_tokens=5,
+                input_reference="context:shared",
+            ),
+            Span(
+                span_id="dup-context",
+                name="second lookup",
+                span_type=SpanType.MODEL_CALL,
+                status=RunStatus.SUCCEEDED,
+                input_tokens=2,
+                input_reference="context:shared",
+            ),
+        ],
+    )
+
+
+def test_render_trace_prints_findings_and_next_best_analysis() -> None:
+    console = Console(record=True, width=120)
+    render_trace(console, _run_with_findings())
+    output = console.export_text()
+
+    assert "Run Summary" in output
+    assert "Findings" in output
+    assert "High memory token share" in output
+    assert "High retry overhead" in output
+    assert "Next Best Analysis" in output
+
+
+def test_render_trace_markdown_includes_findings_sections() -> None:
+    markdown = render_trace_markdown(_run_with_findings())
+
+    assert "# Trace Report: trace-demo" in markdown
+    assert "## Findings" in markdown
+    assert "### High memory token share" in markdown
+    assert "### High retry overhead" in markdown
+
+
+def test_render_trace_markdown_escapes_pipe_characters() -> None:
+    run = _run_with_findings()
+    run.spans[0].name = "memory | lookup"
+
+    markdown = render_trace_markdown(run)
+
+    assert "memory \\| lookup" in markdown
+
+
+def test_next_best_analyses_returns_guidance_for_single_finding() -> None:
+    suggestions = next_best_analyses(
+        [
+            Finding(
+                category="memory",
+                title="High memory token share",
+                description="Memory spans consume a large share of recorded tokens.",
+                severity="medium",
+                confidence=1.0,
+            )
+        ]
+    )
+
+    assert suggestions

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ resolution-markers = [
 
 [[package]]
 name = "agenticlens"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What changed

This PR lands the trace/comparison/evaluation work we iterated on locally and packages it for release as `0.4.0`.

It includes:

- first-class `Evidence` on findings and recommendations
- cycle detection, retry attribution, retry outcome classification, and duplicated-context detection for trace analysis
- Markdown trace and comparison reports
- minimum-sample guidance and `--min-samples` enforcement for comparison
- richer deterministic evaluation checks: JSON Schema validation, required output fields, required tool arguments, and turn-count thresholds
- `BusinessRuleEvaluator`
- trusted live Python and HTTP evaluation targets via `evaluate-live`
- import-layer guardrails and targeted regression tests
- schema, README, docs, examples, roadmap, and release metadata updates

## Why it changed

The codebase had grown to support most of the roadmap’s `v0.2`, `v0.2.x`, and `v0.3` scope, but several pieces were either still missing or not fully wired through the CLI, schemas, examples, and docs.

This PR closes those gaps and makes the shipped surface consistent across:

- runtime behavior
- JSON schema contracts
- CLI usage
- examples and docs
- roadmap and release metadata

## Root causes addressed

This PR also fixes a few correctness and release-quality issues discovered during review:

- live targets could override suite `case_id` when returning their own payload field
- trace analysis mutated the input `Run` while computing retry attribution
- the published finding schema no longer matched the runtime `Finding.evidence` shape
- docs and roadmap sections had drifted from the implemented feature set

## User and developer impact

Developers can now:

- save Markdown trace reports with `agenticlens inspect --save`
- save Markdown comparison reports with `agenticlens compare --format md`
- fail CI when a comparison is under-sampled with `--min-samples`
- evaluate structured outputs and tool arguments without custom code
- run one trusted live Python or HTTP target against the same evaluation suite used for recorded samples
- rely on finding/recommendation provenance as structured evidence

## Commit structure

1. `Add trace comparison provenance features`
2. `Add live evaluation and richer checks`
3. `Add regression tests for trace and evaluation updates`
4. `Document new trace and evaluation workflows`
5. `Bump release metadata to 0.4.0`

## Validation

Ran from the branch tip:

```bash
./.venv/bin/ruff check .
./.venv/bin/ruff format --check .
./.venv/bin/mypy
./.venv/bin/pytest tests/
```

Results:

- `ruff check .` passed
- `ruff format --check .` passed
- `mypy` passed (`67` source files)
- `pytest` passed (`121` tests, `91%` coverage)

## Notes

- `evaluate-live` is intentionally documented and positioned as a trusted developer-facing feature: Python targets execute local code and HTTP targets can reach arbitrary URLs.
- The PR is opened as a draft to make it easy to review the commit stack before requesting final review.