### PR TITLE
docs: document control tower relationship

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ system performed well over time.
   `agentic-chaos`
 - Pre-action agent supervision and decision interception — that belongs in
   `agentic-sidecar`
+- At the ecosystem-role level, `agentic-sidecar` is the **SUPERVISE** layer,
+  while its concrete functionality spans both supervision and governance.
 - A generic MCP server or remote orchestration surface — that belongs in
   `deep-agentic-core-mcp`
 
@@ -127,6 +129,9 @@ simulation.
   `examples/`, or test fixtures that demonstrate expected usage.
 - When a roadmap item or milestone meaningfully changes status, update
   `README.md` and `agenticlens-roadmap.md` in the same change.
+- If that milestone or release changes the public ecosystem story, also update
+  `/home/pramodbn27/PyPi Projects/.github/profile/README.md` and, when
+  relevant, `/home/pramodbn27/PyPi Projects/.github/profile/ROADMAP.md`.
 - When work is packaged as a release-ready change, also update
   `pyproject.toml`, `src/agenticlens/__init__.py`, and `CHANGELOG.md`.
 
@@ -144,5 +149,6 @@ Run `make check` before every push. It runs: lint → format-check → typecheck
 
 1. Bump version in `pyproject.toml`, `src/agenticlens/__init__.py`, and `CHANGELOG.md`
 2. Commit: `git commit -am "release: vX.Y.Z"`
-3. Tag: `git tag vX.Y.Z`
+3. Tag: create an annotated `vX.Y.Z` tag and use the latest `CHANGELOG.md`
+   release section as the tag description
 4. Push: `git push origin main --tags`

--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ AgenticLens remains package-first, local-first, framework-neutral, CI-friendly,
 and advisory-first. It does not require a hosted backend and does not
 automatically change production prompts, models, tools, or routing.
 
+That boundary matters in the broader DeepAgentLabs ecosystem: AgenticLens
+observes and evaluates, while `agenticops-control-tower` is the future
+operator-facing control plane above the package layer rather than a hosted
+requirement of AgenticLens itself.
+
 ## Step-Level Token Optimization
 
 AgenticLens is designed to make token waste visible at the level where engineers

--- a/agenticlens-roadmap.md
+++ b/agenticlens-roadmap.md
@@ -118,6 +118,11 @@ cross-project coordination before they should be marked complete.
 - `deep-agentic-core-mcp`
   Exposes AgenticLens capabilities through MCP and is a useful sibling check
   for CLI/API behavior that is expected to be consumable by hosts and tools.
+- `agenticops-control-tower`
+  Coordinate with: once Control Tower ships real inventory and control-plane
+  surfaces, AgenticLens findings, evaluation summaries, and readiness posture
+  should be centrally visible there without turning AgenticLens into a hosted
+  dashboard product.
 
 For roadmap items with ecosystem impact, contributors should distinguish:
 


### PR DESCRIPTION
## Summary
- clarify that AgenticLens remains package-first and local-first
- note that Control Tower is a future operator-facing layer above the package, not a hosted requirement of AgenticLens
- add the roadmap coordination point for future centralized readiness visibility

## Notes
- branch pushed with `git`
- docs-only PR